### PR TITLE
draft-pr-with-squashにPRテンプレート自動検出機能を追加

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -4,6 +4,7 @@
       "Bash(cat)",
       "Bash(gh pr list:*)",
       "Bash(gh pr view:*)",
+      "Bash(gh pr diff:*)",
       "Bash(gh repo view:*)",
       "Bash(git add:*)",
       "Bash(git diff:*)",


### PR DESCRIPTION
## Summary
- draft-pr-with-squashスキルにPRテンプレート自動検出機能を追加
- `gh repo view --json pullRequestTemplates`でテンプレートを検出
- 複数テンプレートがある場合はユーザーに選択を促す
- テンプレートがない場合は従来通りの動作を維持（後方互換性）

## Test plan
- [ ] テンプレートなしのリポジトリでスキルを実行 → 現行動作と同じであること
- [ ] `.github/pull_request_template.md`があるリポジトリでスキルを実行 → テンプレートが使用されること
- [ ] 複数テンプレートがあるリポジトリでスキルを実行 → 選択プロンプトが表示されること
- [ ] `/skills`コマンドでスキルが正常に読み込まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)