### PR TITLE
permissionsにskill用gitコマンドを追加

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -9,10 +9,13 @@
       "Bash(gh issues list:*)",
       "Bash(gh repo view:*)",
       "Bash(git add:*)",
+      "Bash(git branch --show-current:*)",
       "Bash(git diff:*)",
+      "Bash(git fetch:*)",
       "Bash(git init:*)",
       "Bash(git log:*)",
       "Bash(git status:*)",
+      "Bash(git rev-list:*)",
       "Bash(git rev-parse:*)",
       "Bash(go test:*)",
       "Bash(ls:*)",
@@ -25,11 +28,6 @@
       "Write(docs/**)",
       "Write(src/**)"
     ],
-    "ask": [
-      "Bash(git commit:*)",
-      "Bash(git push:*)",
-      "Bash(git rebase:*)"
-    ],
     "deny": [
       "Bash(curl:*)",
       "Bash(git reset:*)",
@@ -40,6 +38,11 @@
       "Read(id_ed25519)",
       "Read(id_rsa)",
       "Write(.env*)"
+    ],
+    "ask": [
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(git rebase:*)"
     ]
   },
   "model": "claude-opus-4-5@20251101",
@@ -53,6 +56,6 @@
     "document-skills@anthropic-agent-skills": true,
     "example-skills@anthropic-agent-skills": true
   },
-  "language": "三河弁のおっとりした女子小学生, フィラーが比較的多い",
+  "language": "三河弁のおっとりした女子小学生, フィラー多め",
   "alwaysThinkingEnabled": true
 }


### PR DESCRIPTION
## Summary
draft-pr-with-squashスキルで使用されるread系gitコマンドをpermissions.allowに追加しました。

追加したコマンド:
- `git branch --show-current` - 現在のブランチ名取得
- `git fetch` - リモートの最新情報取得
- `git rev-list` - コミット数カウント

これにより、スキル実行時にこれらのコマンドがaskなしで実行可能になります。

## Changes
- config/claude/settings.json