### PR TITLE
refactor(draft-pr): Extract commands to Taskfile for better maintainability

### DIFF
--- a/config/claude/skills/usadamasa-draft-pr/Taskfile.yml
+++ b/config/claude/skills/usadamasa-draft-pr/Taskfile.yml
@@ -1,0 +1,37 @@
+version: '3'
+
+tasks:
+  get-base:
+    desc: デフォルトブランチ名を取得
+    cmds:
+      - gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+    silent: true
+
+  rebase-fixup:
+    desc: 非対話的rebaseでfixup実行
+    vars:
+      BASE_BRANCH: '{{.CLI_ARGS}}'
+    cmds:
+      - GIT_SEQUENCE_EDITOR="sed -i '' '2,\$s/^pick/fixup/'" git rebase -i "origin/{{.BASE_BRANCH}}"
+
+  get-commit-title:
+    desc: 最新コミットのタイトル抽出
+    cmds:
+      - git log -1 --pretty=%s
+    silent: true
+
+  get-pr-template:
+    desc: PRテンプレート取得 (JSON)
+    cmds:
+      - gh repo view --json pullRequestTemplates -q '.pullRequestTemplates'
+    silent: true
+
+  create-pr:
+    desc: Draft PRを作成
+    cmds:
+      - gh pr create --draft --base "{{.BASE}}" --title "{{.TITLE}}" --body "{{.BODY}}"
+
+  update-pr:
+    desc: 既存PRを更新
+    cmds:
+      - gh pr edit --title "{{.TITLE}}" --body "{{.BODY}}"


### PR DESCRIPTION
## Summary

draft-prスキルのコマンドをTaskfileに抽出し、メンテナンス性を向上させました。

主な変更:
- 直接のghコマンドやgitコマンドをTaskfileのタスク呼び出しに置き換え
- 新しいTaskfile.ymlを追加し、以下のタスクを定義:
  - `get-base`: デフォルトブランチ名取得
  - `rebase-fixup`: 非対話的rebaseでfixup実行
  - `get-commit-title`: 最新コミットのタイトル抽出
  - `get-pr-template`: PRテンプレート取得
  - `create-pr`: Draft PR作成
  - `update-pr`: 既存PR更新

## Changes
- config/claude/skills/usadamasa-draft-pr/SKILL.md
- config/claude/skills/usadamasa-draft-pr/Taskfile.yml