### PR TITLE
docs(claude): Add Claude Code configuration documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 This is a personal dotfiles repository for macOS development environment setup. The structure follows XDG Base Directory standards:
 
 - `config/` - Contains all configuration files organized by tool
-  - `git/` - Git configuration and global gitignore  
+  - `claude/` - Claude Code configuration (symlinked to `~/.claude`)
+    - `CLAUDE.md` - Global Claude Code instructions
+    - `settings.json` - Permissions, plugins, model settings
+    - `skills/` - Global skills (available in all projects)
+    - `commands/` - Custom commands
+  - `git/` - Git configuration and global gitignore
   - `npm/` - npm configuration with custom registry and cache settings
   - `vim/` - Vim configuration with XDG compliance and plugin management
   - `zsh/` - Zsh configuration with oh-my-zsh integration
@@ -112,3 +117,32 @@ When working with long commands in this repository:
 - Sort options and packages alphabetically when syntactically appropriate
 - Maintain consistent indentation for readability
 - Follow the established pattern in existing commands (e.g., `brew install` formatting)
+
+## Claude Code Configuration
+
+This repository manages Claude Code configuration at the global user level.
+
+### Symlink Structure
+The `config/claude/` directory is symlinked to `~/.claude` during `task setup`.
+This means all configurations in this directory apply globally to all projects.
+
+### Global Skills
+Skills in `config/claude/skills/` are available across all projects:
+- `usadamasa-draft-pr` - Draft PR creation workflow with fixup commits
+- `usadamasa-skill-creation-guide` - Guide for creating Claude Code skills
+- `content-research-writer` - Content writing assistant with research
+- `cdp-confluence-guide` - CADDi Data Platform Confluence guide
+
+### Adding New Global Skills
+```sh
+# Create skill directory and SKILL.md
+mkdir -p config/claude/skills/<skill-name>
+touch config/claude/skills/<skill-name>/SKILL.md
+
+# Verify skill is recognized
+# Run /skills in Claude Code
+```
+
+### Note on Skill Scope
+- **Global skills** → Place in `config/claude/skills/` (applies to all projects)
+- **Project-specific skills** → Place in `.claude/skills/` within the project repository

--- a/config/claude/CLAUDE.md
+++ b/config/claude/CLAUDE.md
@@ -1,5 +1,9 @@
 # CLAUDE.md
 
+> **Note:** This directory (`config/claude/`) is symlinked to `~/.claude` via dotfiles setup.
+> All configurations here apply globally to all projects.
+> Source: `~/src/github.com/usadamasa/dotfile/config/claude/`
+
 ## Conversation Guidelines
 
 ### 言語設定
@@ -34,6 +38,14 @@
 
 ## Skills 実装
 
-https://code.claude.com/docs/en/skills を参照し､適切な形式で記述してください｡
+<https://code.claude.com/docs/en/skills> を参照し､適切な形式で記述してください｡
 作成後､Skillsとして利用可能であることを `/skills` で検証してください｡
-また､特に指示がなければskillsはリポジトリレベルに配置してください｡
+
+### スキルの配置場所
+
+| スコープ | 配置場所 | 説明 |
+| --------- | --------- | ------ |
+| グローバル | `config/claude/skills/` (= `~/.claude/skills/`) | 全プロジェクトで利用可能 |
+| プロジェクト | プロジェクトの `.claude/skills/` | そのプロジェクトのみで利用可能 |
+
+特に指示がなければグローバルスコープ(`config/claude/skills/`)に配置してください｡


### PR DESCRIPTION
## Summary

Claude Code設定に関するドキュメントを追加しました。

- プロジェクトのCLAUDE.mdにディレクトリ構造を追記
- シンボリックリンク構造とグローバルスキル設定のドキュメントを追加
- スキルの配置場所に関するスコープテーブルを追加
- 新しいグローバルスキルの追加手順を記載

## Changes
- CLAUDE.md
- config/claude/CLAUDE.md