### PR TITLE
feat(zsh): Add git worktree support to peco-gcop

### DIFF
--- a/config/git/config
+++ b/config/git/config
@@ -33,3 +33,9 @@
   prune = true
 [init]
   defaultBranch = main
+[wt]
+	copyignored = true
+	copyuntracked = true
+	copymodified = true
+	hook = direnv allow
+	basedir = ../worktrees/{gitroot}

--- a/config/zsh/.zshrc
+++ b/config/zsh/.zshrc
@@ -89,5 +89,8 @@ source ${ZDOTDIR}/history_settings.sh
 source ${ZDOTDIR}/funcs/peco-select-history.sh
 source ${ZDOTDIR}/funcs/peco-src.sh
 
+# https://github.com/k1LoW/git-wt
+eval "$(git wt --init zsh)"
+
 # local env
 [ -s "${ZDOTDIR}/.zshrc.local" ] && . "${ZDOTDIR}/.zshrc.local"


### PR DESCRIPTION
## Summary

peco-gcop 関数に git worktree 対応を追加し、ブランチ選択時に worktree の種類（BASE/worktree）を区別して表示するようにした。

### 主な変更点

- peco-gcop でブランチ選択時に BASE/worktree タグを表示
- BASE または worktree タグ付きブランチを選択すると、cd で該当ディレクトリに移動
- git-wt ツールの設定と初期化を追加

## Changes
- config/git/config
- config/zsh/.zshrc
- config/zsh/funcs/peco-src.sh