### PR TITLE
feat(peco-gcop): Add unit tests with bats-core and refactor for testability

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -40,6 +40,13 @@ tasks:
         echo "oh-my-zsh: $(test -d "$HOME/.oh-my-zsh" && echo '✓' || echo '✗')"
         echo "Claude設定: $(test -L "$HOME/.claude" && echo '✓' || echo '✗')"
 
+  test:
+    desc: テストを実行
+    cmds:
+      - echo "🧪 テストを実行中..."
+      - bats tests/
+      - echo "✅ テスト完了"
+
   format:
     desc: .editorconfigに従ってファイルをフォーマット・修正
     cmds:
@@ -99,6 +106,7 @@ tasks:
       - echo "🛠️ 開発ツールをインストール中..."
       - |
         brew install \
+          bats-core \
           direnv \
           editorconfig \
           gh \

--- a/config/claude/skills/usadamasa-bats-testing/SKILL.md
+++ b/config/claude/skills/usadamasa-bats-testing/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: bats-testing
+description: bats-core を使用したシェルスクリプトの単体テスト作成ガイド。テストの書き方、フィクスチャ、モック、TDD の進め方を提供します。dotfiles リポジトリでの実例を含みます。
+---
+
+# bats-core シェルスクリプトテストガイド
+
+このスキルは、bats-core を使用したシェルスクリプトの単体テスト作成方法を提供します。
+
+## クイックリファレンス
+
+### インストールと実行
+
+```bash
+# インストール
+brew install bats-core
+
+# テスト実行
+bats tests/                    # 全テスト
+bats tests/my-test.bats        # 特定ファイル
+bats --verbose-run tests/      # 詳細出力
+```
+
+### 基本構文
+
+```bash
+#!/usr/bin/env bats
+
+setup() {
+  # 各テスト前に実行
+  load 'helpers/mock.sh'
+  source "$DOTFILE_DIR/script.sh"
+}
+
+teardown() {
+  # 各テスト後に実行
+  cleanup
+}
+
+@test "テストの説明" {
+  run my_command
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"expected"* ]]
+}
+```
+
+### run コマンド
+
+```bash
+run my_command arg1 arg2
+
+$status  # 終了ステータス
+$output  # 標準出力 + 標準エラー
+$lines   # 出力を行ごとに分割した配列
+```
+
+**注意**: `run` はサブシェル実行のため、グローバル変数の変更は親に反映されない
+
+### アサーション
+
+```bash
+[ "$status" -eq 0 ]                    # 成功
+[ "$status" -ne 0 ]                    # 失敗
+[[ "$output" == *"substring"* ]]       # 部分一致
+[[ "$output" != *"unwanted"* ]]        # 不一致
+[ "${#lines[@]}" -eq 5 ]               # 行数
+```
+
+## dotfiles での使用箇所
+
+| ファイル | 説明 |
+|---------|------|
+| `tests/peco-gcop.bats` | peco-gcop 関数のテスト (10 ケース) |
+| `tests/fixtures/git-setup.sh` | テスト用 Git リポジトリ作成 |
+| `tests/helpers/peco-mock.sh` | peco コマンドのモック |
+| `tests/helpers/zle-mock.sh` | zsh zle/bindkey のモック |
+
+### ディレクトリ構造
+
+```
+tests/
+├── *.bats              # メインテストファイル
+├── fixtures/           # テスト用データ・セットアップ
+└── helpers/            # モック・ヘルパー関数
+```
+
+## TDD ワークフロー
+
+```
+1. Red: テストを書く → 失敗を確認 → コミット
+2. Green: 実装する → テストパス → コミット
+3. Refactor: コード改善 → テスト維持
+```
+
+## よくある問題
+
+| 問題 | 解決 |
+|-----|------|
+| `bindkey: command not found` | モックをテスト対象より先に読み込む |
+| 変数が変更されない | `run` の代わりに直接実行 |
+| `trap: undefined signal: RETURN` | `trap ... EXIT` を使う (bash 互換) |
+
+## 詳細情報
+
+モックの作成、フィクスチャの詳細、テスタブルなコード設計については [reference.md](reference.md) を参照してください。

--- a/config/claude/skills/usadamasa-bats-testing/reference.md
+++ b/config/claude/skills/usadamasa-bats-testing/reference.md
@@ -1,0 +1,342 @@
+# bats-core 詳細リファレンス
+
+## 目次
+
+- [モックの作成](#モックの作成)
+- [フィクスチャ](#フィクスチャ)
+- [テスタブルなコード設計](#テスタブルなコード設計)
+- [bash 互換性](#bash-互換性)
+- [トラブルシューティング](#トラブルシューティング)
+
+## モックの作成
+
+### 外部コマンドのモック
+
+peco のような対話的コマンドをモック化する例:
+
+```bash
+#!/usr/bin/env bash
+# helpers/peco-mock.sh
+
+PECO_MOCK_SELECTION=""
+
+peco() {
+  if [ -n "$PECO_MOCK_SELECTION" ]; then
+    echo "$PECO_MOCK_SELECTION"
+  else
+    return 0  # キャンセル
+  fi
+}
+
+export -f peco
+```
+
+テストでの使用:
+
+```bash
+@test "peco で選択した値が使われる" {
+  PECO_MOCK_SELECTION="feature-branch"
+  run my_function
+  [[ "$output" == *"feature-branch"* ]]
+}
+
+@test "peco キャンセル時にエラーにならない" {
+  PECO_MOCK_SELECTION=""
+  run my_function
+  [ "$status" -eq 0 ]
+}
+```
+
+### zsh 専用コマンドのモック
+
+bats は bash で動作するため、zsh 専用コマンドをモック化する必要があります。
+
+```bash
+#!/usr/bin/env bash
+# helpers/zle-mock.sh
+
+# zle 関連変数
+BUFFER=""
+LBUFFER=""
+
+# zle コマンドのモック
+zle() {
+  local cmd="$1"
+  case "$cmd" in
+    accept-line|reset-prompt|clear-screen|-N) ;;
+    *) ;;
+  esac
+}
+
+# bindkey コマンドのモック
+bindkey() {
+  :  # 何もしない
+}
+
+export -f zle
+export -f bindkey
+export BUFFER LBUFFER
+```
+
+### モックの読み込み順序
+
+**重要**: モックはテスト対象より先に読み込む!
+
+```bash
+setup() {
+  DOTFILE_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+
+  # ✅ 正しい順序: モックが先
+  load 'helpers/zle-mock.sh'
+  load 'helpers/peco-mock.sh'
+  load 'fixtures/git-setup.sh'
+
+  # テスト対象は最後
+  source "$DOTFILE_DIR/config/zsh/funcs/peco-src.sh"
+}
+```
+
+## フィクスチャ
+
+### テスト用 Git リポジトリ
+
+dotfiles のブランチを汚さないために、一時ディレクトリにテスト用リポジトリを作成します。
+
+```bash
+#!/usr/bin/env bash
+# fixtures/git-setup.sh
+
+create_test_repo() {
+  TEST_REMOTE=$(mktemp -d)
+  TEST_REPO=$(mktemp -d)
+
+  # bare リポジトリ (remote 用)
+  git init --bare "$TEST_REMOTE" >/dev/null 2>&1
+
+  # 作業リポジトリ
+  git clone "$TEST_REMOTE" "$TEST_REPO" >/dev/null 2>&1
+  cd "$TEST_REPO" || return 1
+
+  # Git 設定
+  git config user.email "test@example.com"
+  git config user.name "Test User"
+
+  # 初期コミット
+  echo "initial" > README.md
+  git add README.md
+  git commit -m "Initial commit" >/dev/null 2>&1
+  git push origin main >/dev/null 2>&1 || git push origin master >/dev/null 2>&1
+
+  export TEST_REPO TEST_REMOTE
+}
+
+cleanup_test_repo() {
+  [ -n "$WORKTREE_PATH" ] && rm -rf "$WORKTREE_PATH"
+  [ -n "$TEST_REPO" ] && rm -rf "$TEST_REPO"
+  [ -n "$TEST_REMOTE" ] && rm -rf "$TEST_REMOTE"
+  unset TEST_REPO TEST_REMOTE WORKTREE_PATH
+}
+```
+
+### ローカルブランチの作成
+
+```bash
+create_local_branch() {
+  local branch_name="$1"
+  git checkout -b "$branch_name" >/dev/null 2>&1
+  echo "$branch_name" > "$branch_name.txt"
+  git add "$branch_name.txt"
+  git commit -m "Add $branch_name" >/dev/null 2>&1
+  git checkout main >/dev/null 2>&1 || git checkout master >/dev/null 2>&1
+}
+```
+
+### リモートのみのブランチ作成
+
+ローカルには存在しない、リモートのみのブランチを作成:
+
+```bash
+create_remote_only_branch() {
+  local branch_name="$1"
+  local original_dir=$(pwd)
+  local tmp_clone=$(mktemp -d)
+
+  # 別クローンで作成してプッシュ
+  git clone "$TEST_REMOTE" "$tmp_clone" >/dev/null 2>&1
+  cd "$tmp_clone" || return 1
+  git config user.email "test@example.com"
+  git config user.name "Test User"
+  git checkout -b "$branch_name" >/dev/null 2>&1
+  echo "$branch_name" > "$branch_name.txt"
+  git add "$branch_name.txt"
+  git commit -m "Add $branch_name" >/dev/null 2>&1
+  git push origin "$branch_name" >/dev/null 2>&1
+
+  cd "$original_dir" || return 1
+  rm -rf "$tmp_clone"
+
+  # 元のリポジトリで fetch
+  git fetch origin >/dev/null 2>&1
+}
+```
+
+### worktree の作成
+
+```bash
+create_worktree() {
+  local branch_name="$1"
+
+  # まずブランチを作成
+  create_local_branch "$branch_name"
+
+  # 一意な worktree パスを生成
+  local worktree_dir=$(mktemp -d)
+  rm -rf "$worktree_dir"  # git worktree add が作成するため削除
+
+  # worktree を追加
+  git worktree add "$worktree_dir" "$branch_name" >/dev/null 2>&1
+
+  export WORKTREE_PATH="$worktree_dir"
+}
+```
+
+## テスタブルなコード設計
+
+### zle 依存の分離
+
+zsh の zle ウィジェットはテストしにくいため、コアロジックを分離します。
+
+```bash
+# ❌ テストしにくい: 全てが1つの関数
+peco-gcop() {
+  local branches=$(git branch -a ...)
+  local selected=$(echo "$branches" | peco)
+  BUFFER="git checkout $selected"
+  zle accept-line
+}
+
+# ✅ テストしやすい: コアロジックを分離
+_peco_gcop_list_branches() {
+  # コアロジック: stdout に出力
+  git branch -a ...
+}
+
+_peco_gcop_checkout() {
+  local branch="$1"
+  git checkout "$branch"
+}
+
+peco-gcop() {
+  # UI層: zle 依存
+  local selected=$(_peco_gcop_list_branches | peco)
+  if [ -n "$selected" ]; then
+    _peco_gcop_checkout "$selected"
+    zle accept-line
+  fi
+}
+```
+
+**命名規則**:
+- プライベート関数は `_` プレフィックス
+- コア関数は stdout に結果を出力
+- UI 関数は zle/BUFFER を操作
+
+### run を使わない直接実行
+
+`run` はサブシェルで実行するため、グローバル変数の変更が親に反映されません。
+
+```bash
+# ❌ BUFFER の変更が確認できない
+@test "BUFFER が設定される" {
+  run _peco_gcop_checkout "branch"
+  [[ "$BUFFER" == *"cd"* ]]  # 失敗
+}
+
+# ✅ 直接実行して変数を確認
+@test "BUFFER が設定される" {
+  BUFFER=""
+  _peco_gcop_checkout "branch"
+  local status=$?
+  [ "$status" -eq 0 ]
+  [[ "$BUFFER" == *"cd"* ]]  # 成功
+}
+```
+
+## bash 互換性
+
+bats は bash で動作するため、zsh 専用機能は使用できません。
+
+| zsh 専用 | bash 互換の代替 |
+|---------|----------------|
+| `trap ... RETURN` | `trap ... EXIT` |
+| `setopt local_options` | (使用しない) |
+| `setopt pipefail` | `set -o pipefail` |
+| `bindkey` | モックで対応 |
+| `zle` | モックで対応 |
+
+### trap の互換性
+
+```bash
+# ❌ zsh 専用
+trap "rm -f '$tmp_file'" RETURN
+
+# ✅ bash 互換
+trap "rm -f '$tmp_file'" EXIT
+```
+
+## トラブルシューティング
+
+### テストがロードできない
+
+**症状**: `load` が失敗する
+
+**解決**:
+- ファイルパスを確認
+- `.sh` 拡張子を省略: `load 'helpers/mock'` (not `load 'helpers/mock.sh'`)
+
+### command not found: bindkey
+
+**症状**: テスト対象の読み込みで失敗
+
+**解決**:
+1. `helpers/zle-mock.sh` を作成
+2. テスト対象より先に読み込む
+
+```bash
+setup() {
+  load 'helpers/zle-mock.sh'  # 先に読み込む
+  source "$DOTFILE_DIR/script.sh"
+}
+```
+
+### グローバル変数が変更されない
+
+**症状**: `run` 後に変数が期待値と異なる
+
+**原因**: `run` はサブシェルで実行される
+
+**解決**: 変数変更を確認する場合は直接実行
+
+```bash
+BUFFER=""
+my_function
+[[ "$BUFFER" == "expected" ]]
+```
+
+### trap: undefined signal: RETURN
+
+**症状**: テスト実行時にエラー
+
+**原因**: `RETURN` は zsh 専用
+
+**解決**: `EXIT` に変更
+
+```bash
+trap "cleanup" EXIT
+```
+
+## 参考リンク
+
+- [bats-core 公式ドキュメント](https://bats-core.readthedocs.io/)
+- [bats-core GitHub](https://github.com/bats-core/bats-core)
+- [TAP (Test Anything Protocol)](https://testanything.org/)

--- a/config/zsh/funcs/peco-src.sh
+++ b/config/zsh/funcs/peco-src.sh
@@ -19,19 +19,20 @@ function peco-src () {
 zle -N peco-src
 bindkey '^]' peco-src
 
-# checkout git branch with peco
-function peco-gcop() {
+# =============================================================================
+# peco-gcop: checkout git branch with peco
+# =============================================================================
+
+# Core function: List branches with labels
+# Outputs branch list to stdout with (current), (local), (worktree), (BASE) labels
+_peco_gcop_list_branches() {
   # Check if inside a git repository
   if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    echo -n "peco-gcop: Error: Not in a git repository" >&2
-    zle accept-line
+    echo "peco-gcop: Error: Not in a git repository" >&2
     return 1
   fi
 
-  # Enable pipefail to catch errors in pipeline
-  setopt local_options pipefail
-
-  # Get current branch for highlighting
+  # Get current branch
   local current_branch=$(git symbolic-ref --short HEAD 2>/dev/null)
 
   # Create temporary files for branch categorization
@@ -39,7 +40,7 @@ function peco-gcop() {
   local wt_file=$(mktemp)
   local base_file=$(mktemp)
 
-  # Set up trap to ensure cleanup on function exit
+  # Set up trap to ensure cleanup (use EXIT for bash compatibility)
   trap "rm -f '$tmp_file' '$wt_file' '$base_file'" EXIT
 
   git branch --format="%(refname:short)" > "$tmp_file"
@@ -48,113 +49,122 @@ function peco-gcop() {
   local git_common_dir=$(git rev-parse --git-common-dir)
   local main_wt_path
   if [[ "$git_common_dir" == ".git" ]]; then
-    # Currently in the main worktree
     main_wt_path=$(git rev-parse --show-toplevel)
   else
-    # Currently in an added worktree
     main_wt_path=$(dirname "$git_common_dir")
   fi
   local current_wt_path=$(git rev-parse --show-toplevel)
 
-  # Build worktree map: branch -> path
-  typeset -A worktree_map
-  local current_path=""
-  while IFS= read -r line; do
-    if [[ $line =~ ^worktree\ (.+)$ ]]; then
-      current_path="${match[1]}"
-    elif [[ $line =~ ^branch\ refs/heads/(.+)$ ]]; then
-      worktree_map[${match[1]}]="$current_path"
-    fi
-  done < <(git worktree list --porcelain)
-
-  # Write worktree branches to files for Perl script, categorizing as BASE or worktree
-  for branch in ${(k)worktree_map}; do
-    local wt_path="${worktree_map[$branch]}"
-    if [[ "$wt_path" == "$current_wt_path" ]]; then
-      # Current worktree's branch - skip (will be marked as current)
-      continue
-    elif [[ "$wt_path" == "$main_wt_path" ]]; then
-      # Main worktree's branch
-      echo "$branch" >> "$base_file"
-    else
-      # Added worktree's branch
-      echo "$branch" >> "$wt_file"
-    fi
-  done
+  # Get worktree branches using awk (bash compatible)
+  git worktree list --porcelain 2>/dev/null | \
+    awk -v main_wt="$main_wt_path" -v current_wt="$current_wt_path" '
+      /^worktree / { wt = substr($0, 10) }
+      /^branch / {
+        branch = substr($0, 19)
+        if (wt == current_wt) {
+          # Current worktree - skip
+        } else if (wt == main_wt) {
+          print branch > "'"$base_file"'"
+        } else {
+          print branch > "'"$wt_file"'"
+        }
+      }
+    '
 
   # List and format branches
-  local selected_branch=$(
-    git branch -a --sort=refname |
-      grep -v -e '->' |
-      perl -pe 's/^\h+//g' |
-      perl -pe 's/^\* (.*)$/\1 (current)/' |
-      perl -pe 's/^\+ //' |
-      perl -pe 's#^remotes/origin/##' |
-      perl -nle 'print if !$c{$_}++' |
-      perl -e '
-        open(my $fh, "<", "'"$tmp_file"'") or die;
-        my %locals = map { chomp; $_ => 1 } <$fh>;
-        close($fh);
-        open(my $wt, "<", "'"$wt_file"'") or die;
-        my %worktrees = map { chomp; $_ => 1 } <$wt>;
+  git branch -a --sort=refname | \
+    grep -v -e '->' | \
+    perl -pe 's/^[\h\*\+]+//g' | \
+    perl -pe 's#^remotes/origin/##' | \
+    perl -nle 'print if !$c{$_}++' | \
+    perl -e '
+      my $current = "'"$current_branch"'";
+      open(my $fh, "<", "'"$tmp_file"'") or die;
+      my %locals = map { chomp; $_ => 1 } <$fh>;
+      close($fh);
+      my %worktrees;
+      if (open(my $wt, "<", "'"$wt_file"'")) {
+        %worktrees = map { chomp; $_ => 1 } <$wt>;
         close($wt);
-        open(my $base, "<", "'"$base_file"'") or die;
-        my %bases = map { chomp; $_ => 1 } <$base>;
+      }
+      my %bases;
+      if (open(my $base, "<", "'"$base_file"'")) {
+        %bases = map { chomp; $_ => 1 } <$base>;
         close($base);
-        my %seen;
-        my @lines = <>;
-        # First pass: collect current branch names
-        for (@lines) {
-          chomp;
-          if (/^(.+) \(current\)$/) {
-            $seen{$1} = 1;
-          }
+      }
+      while (<>) {
+        chomp;
+        my $branch = $_;
+        if ($branch eq $current) {
+          print "$branch (current)\n";
+        } elsif ($bases{$branch}) {
+          print "$branch (BASE)\n";
+        } elsif ($worktrees{$branch}) {
+          print "$branch (worktree)\n";
+        } elsif ($locals{$branch}) {
+          print "$branch (local)\n";
+        } else {
+          print "$branch\n";
         }
-        # Second pass: output with tags
-        for (@lines) {
-          chomp;
-          if (/\(current\)$/) {
-            print "$_\n";
-          } else {
-            my $branch_name = $_;
-            next if $seen{$branch_name};  # Skip if already shown as current
-            $seen{$branch_name} = 1;      # Mark as seen
-            if ($bases{$branch_name}) {
-              print "$branch_name (BASE)\n";
-            } elsif ($worktrees{$branch_name}) {
-              print "$branch_name (worktree)\n";
-            } elsif ($locals{$branch_name}) {
-              print "$branch_name (local)\n";
-            } else {
-              print "$branch_name\n";
-            }
-          }
-        }
-      ' |
-      peco --query "$LBUFFER" --prompt="BRANCH>"
-  )
+      }
+    '
+}
+
+# Core function: Checkout branch or navigate to worktree
+# $1: branch name (may include label)
+_peco_gcop_checkout() {
+  local selected_branch="$1"
+
+  # Remove label to get branch name
+  local branch_name=$(echo "$selected_branch" | perl -pe 's/ \((current|local|worktree|BASE)\)$//')
+
+  # Check if this is a worktree branch
+  local worktree_path=$(git worktree list --porcelain 2>/dev/null | \
+    awk -v branch="$branch_name" '
+      /^worktree / { wt = substr($0, 10) }
+      /^branch / && substr($0, 19) == branch { print wt; exit }
+    ')
+
+  if [ -n "$worktree_path" ]; then
+    # Worktree branch - set cd command to BUFFER
+    BUFFER="cd '${worktree_path}'"
+    return 0
+  else
+    # Normal checkout
+    git checkout "$branch_name"
+    return $?
+  fi
+}
+
+# zle widget (UI layer)
+function peco-gcop() {
+  # Check if inside a git repository
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo -n "peco-gcop: Error: Not in a git repository" >&2
+    zle accept-line
+    return 1
+  fi
+
+  # Get branch list and select with peco
+  local selected_branch=$(_peco_gcop_list_branches | peco --query "$LBUFFER" --prompt="BRANCH>")
 
   # Check if a branch was selected
   if [ -n "$selected_branch" ]; then
     if [[ $selected_branch == *"(BASE)"* || $selected_branch == *"(worktree)"* ]]; then
-      # Extract branch name and navigate to worktree directory
-      local branch_name=$(echo "$selected_branch" | perl -pe 's/ \((BASE|worktree)\)$//')
-      local wt_path="${worktree_map[$branch_name]}"
-      BUFFER="cd '${wt_path}'"
+      # Worktree branch - use _peco_gcop_checkout to set BUFFER
+      _peco_gcop_checkout "$selected_branch"
       zle accept-line
     else
       # Remove status suffixes if present
-      selected_branch=$(echo "$selected_branch" | perl -pe 's/ \((current|local)\)$//')
+      local branch_name=$(echo "$selected_branch" | perl -pe 's/ \((current|local)\)$//')
 
       # Set the command to the buffer and execute it
-      BUFFER="git checkout ${selected_branch}"
+      BUFFER="git checkout ${branch_name}"
       zle accept-line
     fi
   else
     zle clear-screen
   fi
-
-  # Trap will handle cleanup automatically
 }
 zle -N peco-gcop
 bindkey '^[' peco-gcop

--- a/tests/fixtures/git-setup.sh
+++ b/tests/fixtures/git-setup.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# テスト用Gitリポジトリのセットアップ
+
+# テスト用リポジトリを作成
+# 戻り値: TEST_REPO と TEST_REMOTE を設定
+create_test_repo() {
+  TEST_REMOTE=$(mktemp -d)
+  TEST_REPO=$(mktemp -d)
+
+  # bare リポジトリ(remote用)を作成
+  git init --bare "$TEST_REMOTE" >/dev/null 2>&1
+
+  # 作業リポジトリを作成
+  git clone "$TEST_REMOTE" "$TEST_REPO" >/dev/null 2>&1
+  cd "$TEST_REPO" || return 1
+
+  # Git設定
+  git config user.email "test@example.com"
+  git config user.name "Test User"
+
+  # 初期コミットを作成
+  echo "initial" > README.md
+  git add README.md
+  git commit -m "Initial commit" >/dev/null 2>&1
+
+  # リモートにプッシュ
+  git push origin main >/dev/null 2>&1 || git push origin master >/dev/null 2>&1
+
+  export TEST_REPO TEST_REMOTE
+}
+
+# ローカルブランチを作成
+# $1: ブランチ名
+create_local_branch() {
+  local branch_name="$1"
+  git checkout -b "$branch_name" >/dev/null 2>&1
+  echo "$branch_name content" > "$branch_name.txt"
+  git add "$branch_name.txt"
+  git commit -m "Add $branch_name" >/dev/null 2>&1
+  git checkout main >/dev/null 2>&1 || git checkout master >/dev/null 2>&1
+}
+
+# リモートブランチを作成(ローカルにはない)
+# $1: ブランチ名
+create_remote_only_branch() {
+  local branch_name="$1"
+  local original_dir=$(pwd)
+
+  # 一時ディレクトリでリモートにプッシュ
+  local tmp_clone=$(mktemp -d)
+  git clone "$TEST_REMOTE" "$tmp_clone" >/dev/null 2>&1
+  cd "$tmp_clone" || return 1
+  git config user.email "test@example.com"
+  git config user.name "Test User"
+  git checkout -b "$branch_name" >/dev/null 2>&1
+  echo "$branch_name content" > "$branch_name.txt"
+  git add "$branch_name.txt"
+  git commit -m "Add $branch_name" >/dev/null 2>&1
+  git push origin "$branch_name" >/dev/null 2>&1
+
+  cd "$original_dir" || return 1
+  rm -rf "$tmp_clone"
+
+  # 元のリポジトリでfetch
+  git fetch origin >/dev/null 2>&1
+}
+
+# worktree を作成
+# $1: ブランチ名
+# $2: worktree パス名(一意なパスが自動生成される)
+create_worktree() {
+  local branch_name="$1"
+  local worktree_name="$2"
+
+  # まずブランチを作成
+  create_local_branch "$branch_name"
+
+  # 一意な worktree パスを生成
+  local worktree_dir=$(mktemp -d)
+  rm -rf "$worktree_dir"  # mktemp で作成されたディレクトリを削除(git worktree add が作成するため)
+
+  # worktree を追加
+  git worktree add "$worktree_dir" "$branch_name" >/dev/null 2>&1
+
+  export WORKTREE_PATH="$worktree_dir"
+}
+
+# テスト用リポジトリをクリーンアップ
+cleanup_test_repo() {
+  # worktree ディレクトリを削除
+  if [ -n "$WORKTREE_PATH" ] && [ -d "$WORKTREE_PATH" ]; then
+    rm -rf "$WORKTREE_PATH"
+  fi
+  if [ -n "$TEST_REPO" ] && [ -d "$TEST_REPO" ]; then
+    # worktree を先に削除
+    cd "$TEST_REPO" 2>/dev/null && git worktree prune 2>/dev/null
+    rm -rf "$TEST_REPO"
+  fi
+  if [ -n "$TEST_REMOTE" ] && [ -d "$TEST_REMOTE" ]; then
+    rm -rf "$TEST_REMOTE"
+  fi
+  unset TEST_REPO TEST_REMOTE WORKTREE_PATH
+}

--- a/tests/helpers/peco-mock.sh
+++ b/tests/helpers/peco-mock.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# peco のモック
+
+# モックで返すブランチ名を設定
+# $1: 選択されるブランチ名
+PECO_MOCK_SELECTION=""
+
+# peco のモック実装
+# 入力をそのまま通過させるか、PECO_MOCK_SELECTION が設定されていればそれを返す
+peco() {
+  if [ -n "$PECO_MOCK_SELECTION" ]; then
+    echo "$PECO_MOCK_SELECTION"
+  else
+    # 何も選択されなかった場合(キャンセル)
+    return 0
+  fi
+}
+
+export -f peco

--- a/tests/helpers/zle-mock.sh
+++ b/tests/helpers/zle-mock.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# zle のモック
+
+# zle 関連変数のモック
+BUFFER=""
+LBUFFER=""
+
+# zle コマンドのモック
+zle() {
+  local cmd="$1"
+  case "$cmd" in
+    accept-line)
+      # accept-line は何もしない
+      ;;
+    reset-prompt)
+      # reset-prompt は何もしない
+      ;;
+    clear-screen)
+      # clear-screen は何もしない
+      ;;
+    -N)
+      # ウィジェット登録は何もしない
+      ;;
+    *)
+      # 未知のコマンドは無視
+      ;;
+  esac
+}
+
+# bindkey コマンドのモック
+bindkey() {
+  # 何もしない
+  :
+}
+
+export -f zle
+export -f bindkey
+export BUFFER LBUFFER

--- a/tests/peco-gcop.bats
+++ b/tests/peco-gcop.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+# peco-gcop unit tests
+
+# Load test helpers and fixtures
+setup() {
+  DOTFILE_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+
+  # Load fixtures
+  load 'fixtures/git-setup.sh'
+
+  # Load mocks first (mock bindkey and zle before loading target)
+  load 'helpers/zle-mock.sh'
+  load 'helpers/peco-mock.sh'
+
+  # Load target source
+  source "$DOTFILE_DIR/config/zsh/funcs/peco-src.sh"
+}
+
+teardown() {
+  cleanup_test_repo
+}
+
+# =============================================================================
+# Error cases
+# =============================================================================
+
+@test "returns error when not in a git repository" {
+  cd "$(mktemp -d)"
+
+  run _peco_gcop_list_branches
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Not in a git repository"* ]]
+}
+
+# =============================================================================
+# Branch listing
+# =============================================================================
+
+@test "local branch gets (local) label" {
+  create_test_repo
+  create_local_branch "feature-local"
+
+  run _peco_gcop_list_branches
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"feature-local (local)"* ]]
+}
+
+@test "remote-only branch has no label" {
+  create_test_repo
+  create_remote_only_branch "feature-remote"
+
+  run _peco_gcop_list_branches
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"feature-remote"* ]]
+  [[ "$output" != *"feature-remote (local)"* ]]
+  [[ "$output" != *"feature-remote (current)"* ]]
+}
+
+@test "duplicate branches are removed when local and remote exist" {
+  create_test_repo
+  create_local_branch "feature-both"
+
+  git checkout feature-both >/dev/null 2>&1
+  git push origin feature-both >/dev/null 2>&1
+  git checkout main >/dev/null 2>&1 || git checkout master >/dev/null 2>&1
+
+  run _peco_gcop_list_branches
+
+  [ "$status" -eq 0 ]
+  local count=$(echo "$output" | grep -c "feature-both")
+  [ "$count" -eq 1 ]
+}
+
+@test "current branch gets (current) label" {
+  create_test_repo
+  create_local_branch "feature-current"
+  git checkout feature-current >/dev/null 2>&1
+
+  run _peco_gcop_list_branches
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"feature-current (current)"* ]]
+}
+
+# =============================================================================
+# Worktree support
+# =============================================================================
+
+@test "worktree branch gets (worktree) label" {
+  create_test_repo
+  create_worktree "feature-worktree" "worktree-dir"
+
+  run _peco_gcop_list_branches
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"feature-worktree (worktree)"* ]]
+}
+
+@test "worktree branch selection sets cd command in BUFFER" {
+  create_test_repo
+  create_worktree "feature-worktree" "worktree-dir"
+
+  # Run directly without 'run' to check BUFFER changes
+  BUFFER=""
+  _peco_gcop_checkout "feature-worktree"
+  local status=$?
+
+  [ "$status" -eq 0 ]
+  [[ "$BUFFER" == *"cd"* ]]
+  [[ "$BUFFER" == *"$WORKTREE_PATH"* ]]
+}
+
+# =============================================================================
+# Checkout
+# =============================================================================
+
+@test "can checkout local branch" {
+  create_test_repo
+  create_local_branch "feature-checkout"
+
+  run _peco_gcop_checkout "feature-checkout"
+
+  [ "$status" -eq 0 ]
+  local current=$(git symbolic-ref --short HEAD)
+  [ "$current" = "feature-checkout" ]
+}
+
+@test "can checkout remote branch" {
+  create_test_repo
+  create_remote_only_branch "feature-remote-checkout"
+
+  run _peco_gcop_checkout "feature-remote-checkout"
+
+  [ "$status" -eq 0 ]
+  local current=$(git symbolic-ref --short HEAD)
+  [ "$current" = "feature-remote-checkout" ]
+}
+
+# =============================================================================
+# Cancel handling
+# =============================================================================
+
+@test "peco cancel does not cause error" {
+  create_test_repo
+
+  PECO_MOCK_SELECTION=""
+
+  run peco-gcop
+
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

peco-gcop 関数の単体テストを bats-core で実装し、テスタブルな構造にリファクタリング。
bats-testing skill も追加し、シェルスクリプトテストのベストプラクティスをドキュメント化。

### 主な変更点

- peco-gcop をテスタブルなコア関数に分離
  - `_peco_gcop_list_branches`: ブランチ一覧生成
  - `_peco_gcop_checkout`: checkout 処理
- bats-core テストフレームワークを導入 (10 テストケース)
- テスト用フィクスチャとモックを追加
- bats-testing skill ドキュメントを追加

## Changes

- Taskfile.yml
- config/claude/skills/usadamasa-bats-testing/SKILL.md
- config/claude/skills/usadamasa-bats-testing/reference.md
- config/zsh/funcs/peco-src.sh
- tests/fixtures/git-setup.sh
- tests/helpers/peco-mock.sh
- tests/helpers/zle-mock.sh
- tests/peco-gcop.bats

## Test

```bash
task test
# または
bats tests/peco-gcop.bats
```

All 10 tests pass.