### PR TITLE
feat(peco-gcop): Add prefix symbols to branch list display

### DIFF
--- a/config/zsh/funcs/peco-src.sh
+++ b/config/zsh/funcs/peco-src.sh
@@ -96,15 +96,15 @@ _peco_gcop_list_branches() {
         chomp;
         my $branch = $_;
         if ($branch eq $current) {
-          print "$branch (current)\n";
+          print "* $branch (current)\n";
         } elsif ($bases{$branch}) {
-          print "$branch (BASE)\n";
+          print "# $branch (BASE)\n";
         } elsif ($worktrees{$branch}) {
-          print "$branch (worktree)\n";
+          print "+ $branch (worktree)\n";
         } elsif ($locals{$branch}) {
-          print "$branch (local)\n";
+          print "~ $branch (local)\n";
         } else {
-          print "$branch\n";
+          print "  $branch\n";
         }
       }
     '
@@ -115,8 +115,8 @@ _peco_gcop_list_branches() {
 _peco_gcop_checkout() {
   local selected_branch="$1"
 
-  # Remove label to get branch name
-  local branch_name=$(echo "$selected_branch" | perl -pe 's/ \((current|local|worktree|BASE)\)$//')
+  # Remove prefix symbol and label to get branch name
+  local branch_name=$(echo "$selected_branch" | perl -pe 's/^[*#+~ ] //; s/ \((current|local|worktree|BASE)\)$//')
 
   # Check if this is a worktree branch
   local worktree_path=$(git worktree list --porcelain 2>/dev/null | \
@@ -155,8 +155,8 @@ function peco-gcop() {
       _peco_gcop_checkout "$selected_branch"
       zle accept-line
     else
-      # Remove status suffixes if present
-      local branch_name=$(echo "$selected_branch" | perl -pe 's/ \((current|local)\)$//')
+      # Remove prefix symbol and status suffixes if present
+      local branch_name=$(echo "$selected_branch" | perl -pe 's/^[*#+~ ] //; s/ \((current|local)\)$//')
 
       # Set the command to the buffer and execute it
       BUFFER="git checkout ${branch_name}"

--- a/tests/peco-gcop.bats
+++ b/tests/peco-gcop.bats
@@ -44,7 +44,7 @@ teardown() {
   run _peco_gcop_list_branches
 
   [ "$status" -eq 0 ]
-  [[ "$output" == *"feature-local (local)"* ]]
+  [[ "$output" == *"~ feature-local (local)"* ]]
 }
 
 @test "remote-only branch has no label" {
@@ -54,9 +54,9 @@ teardown() {
   run _peco_gcop_list_branches
 
   [ "$status" -eq 0 ]
-  [[ "$output" == *"feature-remote"* ]]
-  [[ "$output" != *"feature-remote (local)"* ]]
-  [[ "$output" != *"feature-remote (current)"* ]]
+  [[ "$output" == *"  feature-remote"* ]]
+  [[ "$output" != *"~ feature-remote (local)"* ]]
+  [[ "$output" != *"* feature-remote (current)"* ]]
 }
 
 @test "duplicate branches are removed when local and remote exist" {
@@ -82,7 +82,7 @@ teardown() {
   run _peco_gcop_list_branches
 
   [ "$status" -eq 0 ]
-  [[ "$output" == *"feature-current (current)"* ]]
+  [[ "$output" == *"* feature-current (current)"* ]]
 }
 
 # =============================================================================
@@ -96,7 +96,7 @@ teardown() {
   run _peco_gcop_list_branches
 
   [ "$status" -eq 0 ]
-  [[ "$output" == *"feature-worktree (worktree)"* ]]
+  [[ "$output" == *"+ feature-worktree (worktree)"* ]]
 }
 
 @test "worktree branch selection sets cd command in BUFFER" {


### PR DESCRIPTION
## Summary
- Add visual prefix symbols to peco-gcop branch list for better scanability
- `*` for current, `+` for worktree, `#` for BASE, `~` for local, space for remote
- Update tests to match new display format

## Test plan
- [x] Run `bats tests/peco-gcop.bats` - all 10 tests pass
- [ ] Manual test: Press `Esc` in terminal to launch peco-gcop and verify symbols display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)