### PR TITLE
feat(draft-pr): Add git worktree support via USER_WORKING_DIR

### DIFF
--- a/config/claude/skills/usadamasa-draft-pr/SKILL.md
+++ b/config/claude/skills/usadamasa-draft-pr/SKILL.md
@@ -202,3 +202,8 @@ ${CHANGED_FILES}"
 - **gh pr create の非対話モード**: 非対話モードでは `--title` と `--body` の両方が必須
 - **デフォルトPR body構造**: テンプレートがない場合でも「Summary」と「Changes」セクションを含む最低限の構造を自動生成
 - **Summary生成**: コミットメッセージに本文があればそれを使用。なければ差分（`git diff`）を読み取って変更内容の要約を生成
+- **Worktree対応**: git worktree 環境でも正常に動作。Taskfile の各タスクは `USER_WORKING_DIR`（コマンド実行元ディレクトリ）で実行されるため、worktree 内でも正しいリポジトリコンテキストで動作する
+- **Taskfile経由のBODY制限**: Taskfile の `create-pr` / `update-pr` タスク経由で BODY を渡す場合、以下の制限がある:
+  - バッククォート（`` ` ``）はシェルのコマンド置換として解釈されるため、`\`` でエスケープが必要
+  - `{{...}}` は go-task のテンプレート変数として展開される
+  - これらの問題を回避するには、`gh pr create` / `gh pr edit` を直接使用する

--- a/config/claude/skills/usadamasa-draft-pr/Taskfile.yml
+++ b/config/claude/skills/usadamasa-draft-pr/Taskfile.yml
@@ -3,12 +3,14 @@ version: '3'
 tasks:
   get-base:
     desc: デフォルトブランチ名を取得
+    dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - gh repo view --json defaultBranchRef -q .defaultBranchRef.name
     silent: true
 
   rebase-fixup:
     desc: 非対話的rebaseでfixup実行
+    dir: '{{.USER_WORKING_DIR}}'
     vars:
       BASE_BRANCH: '{{.CLI_ARGS}}'
     cmds:
@@ -16,22 +18,26 @@ tasks:
 
   get-commit-title:
     desc: 最新コミットのタイトル抽出
+    dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - git log -1 --pretty=%s
     silent: true
 
   get-pr-template:
     desc: PRテンプレート取得 (JSON)
+    dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - gh repo view --json pullRequestTemplates -q '.pullRequestTemplates'
     silent: true
 
   create-pr:
     desc: Draft PRを作成
+    dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - gh pr create --draft --base "{{.BASE}}" --title "{{.TITLE}}" --body "{{.BODY}}"
 
   update-pr:
     desc: 既存PRを更新
+    dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - gh pr edit --title "{{.TITLE}}" --body "{{.BODY}}"


### PR DESCRIPTION
## Summary

draft-pr スキルの Taskfile を git worktree 環境で正しく動作するように修正。

go-task はデフォルトで Taskfile があるディレクトリでコマンドを実行するため、worktree から呼び出すと git/gh コマンドが意図しないディレクトリで実行される問題があった。各タスクに `dir: '{{.USER_WORKING_DIR}}'` を追加することで、呼び出し元ディレクトリでコマンドが実行されるようになった。

また、skill-creation-guide に go-task との連携セクションを追加し、この仕様を文書化した。

## Changes
- config/claude/skills/usadamasa-draft-pr/SKILL.md
- config/claude/skills/usadamasa-draft-pr/Taskfile.yml
- config/claude/skills/usadamasa-skill-creation-guide/SKILL.md