### PR TITLE
feat: add worktree support to git mc alias

### DIFF
--- a/config/git/config
+++ b/config/git/config
@@ -28,7 +28,21 @@
   process = git-lfs filter-process
   required = true
 [alias]
-  mc = !git switch $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@') && git pull origin HEAD && gh poi
+  mc = "!f() { \
+    default_branch=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'); \
+    current_branch=$(git rev-parse --abbrev-ref HEAD); \
+    if [ \"$current_branch\" = \"$default_branch\" ]; then \
+      git pull origin HEAD && gh poi; \
+    else \
+      default_wt_path=$(git worktree list | grep \"\\[$default_branch\\]\" | awk '{print $1}'); \
+      original_dir=$(pwd); \
+      if [ -n \"$default_wt_path\" ] && [ -d \"$default_wt_path\" ]; then \
+        cd \"$default_wt_path\" && git pull origin HEAD && cd \"$original_dir\" && gh poi; \
+      else \
+        git fetch origin \"$default_branch:$default_branch\" && gh poi; \
+      fi \
+    fi \
+  }; f"
 [fetch]
   prune = true
 [init]

--- a/tests/git-mc.bats
+++ b/tests/git-mc.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+# git mc unit tests
+# worktree対応版 git mc コマンドのテスト
+
+setup() {
+  DOTFILE_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  load 'fixtures/git-setup.sh'
+  load 'helpers/gh-poi-mock.sh'
+  setup_gh_poi_mock
+}
+
+teardown() {
+  cleanup_gh_poi_mock
+  cleanup_test_repo
+}
+
+# =============================================================================
+# デフォルトブランチでの動作
+# =============================================================================
+
+@test "on default branch: pulls and runs gh poi" {
+  create_test_repo
+  cd "$TEST_REPO"
+
+  run git_mc
+
+  [ "$status" -eq 0 ]
+  gh_poi_was_called
+}
+
+@test "on default branch: pulls latest changes" {
+  create_test_repo
+  cd "$TEST_REPO"
+
+  # リモートに新しいコミットを追加
+  add_remote_commit
+  local remote_sha=$(git rev-parse origin/main 2>/dev/null || git rev-parse origin/master)
+
+  run git_mc
+
+  [ "$status" -eq 0 ]
+  local local_sha=$(git rev-parse HEAD)
+  [ "$local_sha" = "$remote_sha" ]
+}
+
+# =============================================================================
+# worktree での動作
+# =============================================================================
+
+@test "in worktree: fetches default branch without switching" {
+  create_test_repo
+  cd "$TEST_REPO"
+  create_worktree "feature-wt" "wt-dir"
+  cd "$WORKTREE_PATH"
+
+  local before_branch=$(git rev-parse --abbrev-ref HEAD)
+  run git_mc
+  local after_branch=$(git rev-parse --abbrev-ref HEAD)
+
+  [ "$status" -eq 0 ]
+  [ "$before_branch" = "$after_branch" ]
+  [ "$before_branch" = "feature-wt" ]
+}
+
+@test "in worktree: gh poi is called" {
+  create_test_repo
+  cd "$TEST_REPO"
+  create_worktree "feature-wt" "wt-dir"
+  cd "$WORKTREE_PATH"
+
+  run git_mc
+
+  [ "$status" -eq 0 ]
+  gh_poi_was_called
+}
+
+@test "in worktree: default branch is updated via cd" {
+  create_test_repo
+  cd "$TEST_REPO"
+  create_worktree "feature-wt" "wt-dir"
+
+  # リモートに新しいコミットを追加
+  add_remote_commit
+  local remote_sha=$(git rev-parse origin/main 2>/dev/null || git rev-parse origin/master)
+
+  cd "$WORKTREE_PATH"
+  run git_mc
+
+  [ "$status" -eq 0 ]
+  # cd方式でデフォルトブランチのworktreeに移動してpullするので、ローカルmainも最新化される
+  local local_sha=$(git rev-parse main 2>/dev/null || git rev-parse master)
+  [ "$local_sha" = "$remote_sha" ]
+}
+
+@test "in worktree: returns to original directory after git mc" {
+  create_test_repo
+  cd "$TEST_REPO"
+  create_worktree "feature-wt" "wt-dir"
+  cd "$WORKTREE_PATH"
+
+  local original_dir=$(pwd)
+  run git_mc
+  local after_dir=$(pwd)
+
+  [ "$status" -eq 0 ]
+  [ "$original_dir" = "$after_dir" ]
+}
+
+# =============================================================================
+# 通常のfeatureブランチでの動作
+# =============================================================================
+
+@test "on feature branch: stays on current branch" {
+  create_test_repo
+  cd "$TEST_REPO"
+  create_local_branch "feature-test"
+  git checkout feature-test >/dev/null 2>&1
+
+  run git_mc
+
+  [ "$status" -eq 0 ]
+  local current=$(git rev-parse --abbrev-ref HEAD)
+  [ "$current" = "feature-test" ]
+}
+
+@test "on feature branch: default branch is updated" {
+  create_test_repo
+  cd "$TEST_REPO"
+  create_local_branch "feature-test"
+  git checkout feature-test >/dev/null 2>&1
+
+  # リモートに新しいコミットを追加
+  add_remote_commit
+  local remote_sha=$(git rev-parse origin/main 2>/dev/null || git rev-parse origin/master)
+
+  run git_mc
+
+  [ "$status" -eq 0 ]
+  # featureブランチでもmainのworktreeにcdしてpullするので、ローカルmainも最新化される
+  local local_sha=$(git rev-parse main 2>/dev/null || git rev-parse master)
+  [ "$local_sha" = "$remote_sha" ]
+}
+
+@test "on feature branch: gh poi is called" {
+  create_test_repo
+  cd "$TEST_REPO"
+  create_local_branch "feature-test"
+  git checkout feature-test >/dev/null 2>&1
+
+  run git_mc
+
+  [ "$status" -eq 0 ]
+  gh_poi_was_called
+}

--- a/tests/helpers/gh-poi-mock.sh
+++ b/tests/helpers/gh-poi-mock.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# gh poi のモック
+
+# マーカーファイルを使用してgh poiの呼び出しを追跡
+# (runコマンドがサブシェルで実行されるため、環境変数では追跡できない)
+
+setup_gh_poi_mock() {
+  GH_POI_MARKER_FILE=$(mktemp)
+  export GH_POI_MARKER_FILE
+}
+
+cleanup_gh_poi_mock() {
+  [ -n "$GH_POI_MARKER_FILE" ] && rm -f "$GH_POI_MARKER_FILE"
+  unset GH_POI_MARKER_FILE
+}
+
+gh_poi_was_called() {
+  [ -f "$GH_POI_MARKER_FILE" ] && grep -q "called" "$GH_POI_MARKER_FILE"
+}
+
+gh() {
+  if [ "$1" = "poi" ]; then
+    echo "called" > "$GH_POI_MARKER_FILE"
+    return 0
+  fi
+  command gh "$@"
+}
+export -f gh


### PR DESCRIPTION
## Summary

- Update `git mc` alias to handle worktree environments where the default branch may be checked out in another worktree
- When on a non-default branch, find the worktree containing the default branch, cd there to pull, then return to original directory
- Fall back to `git fetch origin main:main` for non-worktree scenarios (when main is not checked out anywhere)

## Test plan

- [x] `bats tests/git-mc.bats` - 全9テストがパス
- [ ] デフォルトブランチで `git mc` を実行して動作確認
- [ ] worktree環境で `git mc` を実行して動作確認
- [ ] 通常のfeatureブランチで `git mc` を実行して動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)