### PR TITLE
feat: PreToolUseフックによるホームディレクトリ走査防止

### DIFF
--- a/config/claude/hooks/guard-home-dir.sh
+++ b/config/claude/hooks/guard-home-dir.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# ホームディレクトリ走査防止フック
+# 許可パス以外の ${HOME} 配下アクセスを deny する
+readonly INPUT=$(cat)
+readonly TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name')
+readonly PROJECT_DIR=$(echo "$INPUT" | jq -r '.cwd')
+
+# 許可するパス一覧(追加削除はここで管理)
+readonly ALLOWED_PATHS=(
+  "$PROJECT_DIR"
+  "$HOME/.claude"
+  "$HOME/obsidian"
+)
+
+# ファイルパスを取得(ツールごとに異なるキー)
+case "$TOOL_NAME" in
+  Read|Edit|Write)
+    FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+    ;;
+  Glob|Grep)
+    FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.path // empty')
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+# パスが空ならデフォルト(CWD)として通過
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# 相対パスを絶対パスに変換
+if [[ "$FILE_PATH" != /* ]]; then
+  FILE_PATH="$PROJECT_DIR/$FILE_PATH"
+fi
+readonly FILE_PATH
+
+# ホームディレクトリ配下かチェック
+if [[ "$FILE_PATH" == "$HOME"/* || "$FILE_PATH" == "$HOME" ]]; then
+  # 許可パスに一致すれば通過
+  for allowed in "${ALLOWED_PATHS[@]}"; do
+    if [[ "$FILE_PATH" == "$allowed"/* || "$FILE_PATH" == "$allowed" ]]; then
+      exit 0
+    fi
+  done
+
+  # それ以外のホームディレクトリ配下は deny
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"ホームディレクトリ走査防止: %s はプロジェクトディレクトリおよび許可パスの外にあるためアクセスできません"}}\n' "$FILE_PATH"
+  exit 0
+fi
+
+# ホームディレクトリ外はそのまま通過
+exit 0

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -61,6 +61,7 @@
       "mcp__orm-discovery-mcp-go__*",
       "mcp__plugin_atlassian_atlassian__*",
       "mcp__plugin_context7_context7__*",
+      "Read(~/.claude/**)",
       "Read(.claude/skills/**)",
       "Read(.env.sample)",
       "Read(classes/**)",
@@ -72,6 +73,7 @@
       "WebFetch(domain:camel.apache.org)",
       "WebFetch(domain:cli.github.com)",
       "WebFetch(domain:cloud.google.com)",
+      "Fetch(domain:code.claude.com)",
       "WebFetch(domain:code.claude.com)",
       "WebFetch(domain:developer.hashicorp.com)",
       "WebFetch(domain:developer.mozilla.org)",
@@ -97,6 +99,8 @@
       "WebFetch(domain:www.envoyproxy.io)",
       "WebFetch(domain:www.npmjs.com)",
       "WebSearch",
+      "Write(~/.claude/**)",
+      "Edit(~/.claude/**)",
       "Write(.claude/skills/**)",
       "Write(.env.sample)",
       "Write(.tmp/**)",
@@ -112,12 +116,18 @@
       "Bash(sudo:*)",
       "Bash(wget:*)",
       "Bash(gh auth:*)",
-      "Read(.aws/**)",
+      "Read(~/.aws/**)",
       "Read(.env.development)",
       "Read(.env.local)",
       "Read(.env.production)",
       "Read(.env)",
-      "Read(.ssh/**)",
+      "Read(~/.ssh/**)",
+      "Read(~/.gnupg/**)",
+      "Read(~/.kube/**)",
+      "Read(~/.docker/config.json)",
+      "Read(~/.zsh_history)",
+      "Read(~/.bash_history)",
+      "Read(~/.netrc)",
       "Read(id_ed25519)",
       "Read(id_rsa)",
       "Write(.env.development)",
@@ -169,6 +179,19 @@
   },
   "language": "三河弁のおっとりした女子小学生, フィラー多め",
   "alwaysThinkingEnabled": true,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read|Edit|Write|Glob|Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/guard-home-dir.sh"
+          }
+        ]
+      }
+    ]
+  },
   "sandbox": {
     "enabled": false,
     "autoAllowBashIfSandboxed": true,

--- a/iterm2/com.googlecode.iterm2.plist
+++ b/iterm2/com.googlecode.iterm2.plist
@@ -52,8 +52,16 @@
 	<false/>
 	<key>HideTabNumber</key>
 	<false/>
+	<key>Hotkey</key>
+	<false/>
+	<key>HotkeyChar</key>
+	<integer>32</integer>
+	<key>HotkeyCode</key>
+	<integer>49</integer>
 	<key>HotkeyMigratedFromSingleToMulti</key>
 	<true/>
+	<key>HotkeyModifiers</key>
+	<integer>524288</integer>
 	<key>New Bookmarks</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## Summary
- PreToolUseフック(`guard-home-dir.sh`)を新規追加し、プロジェクトディレクトリ・`~/.claude/`・`~/obsidian/`以外の`~/`配下ファイルアクセスを包括的にdeny
- `settings.json`のdenyルールを正しい絶対パス(`~/.aws/**`、`~/.ssh/**`)に修正し、`~/.gnupg/**`等の機密パスを追加
- allowリストに`Read/Write/Edit(~/.claude/**)`と`Fetch(domain:code.claude.com)`を追加
- iterm2設定の更新

## Test plan
- [ ] hookスクリプトの単体テスト(deny/allowの各パターン)を実行し通過を確認
- [ ] 新セッションで`~/.claude/settings.json`が読めることを確認
- [ ] 新セッションで`~/Documents/`配下が deny されることを確認
- [ ] 通常のプロジェクトファイルが問題なく読めることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)