### PR TITLE
add git clone-bare alias for bare repository setup

### DIFF
--- a/config/git/CLAUDE.md
+++ b/config/git/CLAUDE.md
@@ -35,6 +35,7 @@ Git のグローバル設定ファイル群を管理するディレクトリ。`
 
 ### カスタムエイリアス
 
+- `git clone-bare <url>` - bare clone を `<ghq.root>/<host>/<owner>/<repo>/.git` に配置｡refspec 設定 & fetch & HEAD 自動設定まで一括実行
 - `git mc` - メインブランチに切替 + pull + `gh poi` でマージ済みブランチ削除
 
 ### git-wt (worktree) 設定

--- a/config/git/README.md
+++ b/config/git/README.md
@@ -17,7 +17,7 @@ bare リポジトリをベースに、ブランチごとに独立した worktree
 
 ```mermaid
 flowchart TD
-    START[ghq get --bare でリポジトリ取得] --> WT_MAIN[git wt main で main worktree 作成]
+    START[git clone-bare でリポジトリ取得] --> WT_MAIN[git wt main で main worktree 作成]
     WT_MAIN --> SETUP[main worktree で初期セットアップ]
     SETUP --> WT_FEATURE[git wt で feature branch worktree 作成 & 移動]
     WT_FEATURE --> DEV[feature branch 上で開発]
@@ -39,10 +39,12 @@ flowchart TD
 ### 1. bare clone でリポジトリ取得
 
 ```bash
-ghq get --bare <repo-url>
+git clone-bare <repo-url>
 ```
 
-`ghq.root` (= `~/src`) 配下に bare リポジトリとしてクローンされる。
+カスタムエイリアスにより、`ghq.root` (= `~/src`) 配下に bare リポジトリをクローンする。
+URL をパースして `~/src/<host>/<owner>/<repo>/.git` に bare clone し、
+refspec 設定・リモートブランチ fetch・HEAD 自動設定まで一括実行する。
 bare clone は作業ディレクトリを持たないため、全ブランチを worktree で管理する前提。
 
 ### 2. main worktree 作成
@@ -52,7 +54,7 @@ git wt main
 ```
 
 bare リポジトリから main ブランチの worktree を作成し、そのディレクトリに移動する。
-`wt.basedir` 設定により、worktree は `../worktrees/{gitroot}` に配置される。
+`wt.basedir` 設定により、worktree はリポジトリルート直下 (`~/src/<host>/<owner>/<repo>/main`) に配置される。
 
 ### 3. 初期セットアップ
 
@@ -151,7 +153,8 @@ git wt -d <feature-branch>
     copyuntracked = true
     copymodified = true
     hook = test -f .envrc && direnv allow || true
-    basedir = ../worktrees/{gitroot}
+    basedir = .
 [alias]
+    clone-bare = "!f() { ... }; f"  # URL をパースして bare clone + refspec 設定
     mc = !git switch $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@') && git pull --tags origin HEAD && gh poi
 ```

--- a/config/git/config
+++ b/config/git/config
@@ -29,7 +29,20 @@
   required = true
 [alias]
   mc = !git wt $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@') && git pull --tags origin HEAD && gh poi
-  reset-wt = !
+  clone-bare = "!f() { \
+    if [ -z \"$1\" ]; then echo \"Usage: git clone-bare <url>\" >&2; return 1; fi; \
+    root=$(git config ghq.root | sed \"s|^~|$HOME|\"); \
+    url=\"$1\"; \
+    path=$(echo \"$url\" | sed -E 's|^[a-z+]*://||; s|^git@||; s|:|/|; s|\\.git$||'); \
+    target=\"$root/$path/.git\"; \
+    if [ -d \"$target\" ]; then echo \"Already exists: $target\" >&2; return 1; fi; \
+    mkdir -p \"$root/$path\" && \
+    git clone --bare \"$url\" \"$target\" && \
+    git -C \"$target\" config remote.origin.fetch \"+refs/heads/*:refs/remotes/origin/*\" && \
+    git -C \"$target\" fetch origin && \
+    git -C \"$target\" remote set-head origin --auto && \
+    echo \"Bare cloned to $root/$path\"; \
+  }; f"
 [fetch]
   prune = true
 [init]
@@ -39,4 +52,4 @@
 	copyuntracked = true
 	copymodified = true
 	hook = test -f .envrc && direnv allow || true
-	basedir = ../worktrees/{gitroot}
+	basedir = .

--- a/tests/clone-bare.bats
+++ b/tests/clone-bare.bats
@@ -1,0 +1,175 @@
+#!/usr/bin/env bats
+# git clone-bare alias tests
+# clone-bare alias の URL パース、ディレクトリ配置、refspec 設定をテストする
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+REAL_GIT_CONFIG="$REPO_ROOT/config/git/config"
+
+setup() {
+  TEST_DIR=$(mktemp -d)
+  TEST_GHQ_ROOT=$(mktemp -d)
+
+  # テスト用グローバル git config を作成
+  # 実際の config を include し、ghq.root だけ上書きする
+  TEST_GIT_CONFIG="$TEST_DIR/gitconfig"
+  cat > "$TEST_GIT_CONFIG" <<EOF
+[include]
+  path = $REAL_GIT_CONFIG
+[ghq]
+  root = $TEST_GHQ_ROOT
+[user]
+  email = test@example.com
+  name = Test User
+[init]
+  defaultBranch = main
+EOF
+
+  export GIT_CONFIG_GLOBAL="$TEST_GIT_CONFIG"
+  export HOME="$TEST_DIR"
+
+  # テスト用リモート bare リポジトリを作成
+  TEST_REMOTE="$TEST_DIR/remote-repo.git"
+  git init --bare "$TEST_REMOTE" >/dev/null 2>&1
+
+  # リモートに初期コミットを追加
+  TEMP_CLONE="$TEST_DIR/temp-clone"
+  git clone "$TEST_REMOTE" "$TEMP_CLONE" >/dev/null 2>&1
+  cd "$TEMP_CLONE"
+  echo "initial" > README.md
+  git add README.md
+  git commit -m "Initial commit" >/dev/null 2>&1
+  git push origin main >/dev/null 2>&1
+  cd "$TEST_DIR"
+  rm -rf "$TEMP_CLONE"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR" "$TEST_GHQ_ROOT"
+  unset GIT_CONFIG_GLOBAL
+}
+
+# テスト内で git コマンドを実行するためのダミーリポジトリに cd する
+# (git alias は git リポジトリ内でないと実行できない)
+enter_dummy_repo() {
+  git init "$TEST_DIR/dummy" >/dev/null 2>&1
+  cd "$TEST_DIR/dummy"
+}
+
+# =============================================================================
+# URL パースのテスト
+# =============================================================================
+
+# URL パースの sed パイプラインを直接テスト
+parse_url() {
+  echo "$1" | sed -E 's|^[a-z+]*://||; s|^git@||; s|:|/|; s|\.git$||'
+}
+
+@test "URL パース: HTTPS URL (.git あり)" {
+  result=$(parse_url "https://github.com/owner/repo.git")
+  [ "$result" = "github.com/owner/repo" ]
+}
+
+@test "URL パース: HTTPS URL (.git なし)" {
+  result=$(parse_url "https://github.com/owner/repo")
+  [ "$result" = "github.com/owner/repo" ]
+}
+
+@test "URL パース: SSH URL (git@形式)" {
+  result=$(parse_url "git@github.com:owner/repo.git")
+  [ "$result" = "github.com/owner/repo" ]
+}
+
+@test "URL パース: SSH URL (ssh://形式)" {
+  result=$(parse_url "ssh://git@github.com/owner/repo.git")
+  [ "$result" = "github.com/owner/repo" ]
+}
+
+@test "URL パース: git:// プロトコル" {
+  result=$(parse_url "git://github.com/owner/repo.git")
+  [ "$result" = "github.com/owner/repo" ]
+}
+
+@test "URL パース: ネストされたパス" {
+  result=$(parse_url "https://gitlab.com/group/subgroup/repo.git")
+  [ "$result" = "gitlab.com/group/subgroup/repo" ]
+}
+
+# =============================================================================
+# エラーケース
+# =============================================================================
+
+@test "引数なしでエラー" {
+  enter_dummy_repo
+  run git clone-bare
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage: git clone-bare"* ]]
+}
+
+@test "既存ディレクトリがある場合エラー" {
+  mkdir -p "$TEST_GHQ_ROOT/example.com/owner/repo/.git"
+  enter_dummy_repo
+  run git clone-bare "https://example.com/owner/repo.git"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Already exists"* ]]
+}
+
+# =============================================================================
+# 正常系: bare clone フロー
+# =============================================================================
+
+# file:// URL からパース後のパスを計算するヘルパー
+get_clone_target() {
+  local parsed_path
+  parsed_path=$(echo "file://$TEST_REMOTE" | sed -E 's|^[a-z+]*://||; s|^git@||; s|:|/|; s|\.git$||')
+  echo "$TEST_GHQ_ROOT/$parsed_path/.git"
+}
+
+@test "bare clone でディレクトリが正しく配置される" {
+  enter_dummy_repo
+  run git clone-bare "file://$TEST_REMOTE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Bare cloned to"* ]]
+}
+
+@test "bare clone で .git ディレクトリが bare リポジトリになっている" {
+  enter_dummy_repo
+  git clone-bare "file://$TEST_REMOTE" >/dev/null 2>&1
+  local target
+  target=$(get_clone_target)
+
+  [ -f "$target/HEAD" ]
+  run git -C "$target" rev-parse --is-bare-repository
+  [ "$output" = "true" ]
+}
+
+@test "bare clone で refspec が正しく設定される" {
+  enter_dummy_repo
+  git clone-bare "file://$TEST_REMOTE" >/dev/null 2>&1
+  local target
+  target=$(get_clone_target)
+
+  run git -C "$target" config remote.origin.fetch
+  [ "$output" = "+refs/heads/*:refs/remotes/origin/*" ]
+}
+
+@test "bare clone で remote HEAD が設定される" {
+  enter_dummy_repo
+  git clone-bare "file://$TEST_REMOTE" >/dev/null 2>&1
+  local target
+  target=$(get_clone_target)
+
+  run git -C "$target" symbolic-ref refs/remotes/origin/HEAD
+  [ "$status" -eq 0 ]
+  [ "$output" = "refs/remotes/origin/main" ]
+}
+
+@test "bare clone でリモートブランチが fetch される" {
+  enter_dummy_repo
+  git clone-bare "file://$TEST_REMOTE" >/dev/null 2>&1
+  local target
+  target=$(get_clone_target)
+
+  run git -C "$target" branch -r
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"origin/main"* ]]
+}


### PR DESCRIPTION
## Summary
- `git clone-bare <url>` エイリアスを追加。URL パースから bare clone、refspec 設定、fetch、HEAD 自動設定までを一括実行する
- `wt.basedir` を `.` に変更し、worktree をリポジトリルート直下に配置するよう簡素化
- bats テストを追加（URL パース、エラーケース、正常系の bare clone フロー）

## Test plan
- [ ] `task test` で bats テストが通ることを確認
- [ ] `git clone-bare <url>` で実際に bare clone できることを確認
- [ ] `git wt main` で worktree がリポジトリルート直下に作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)