### PR TITLE
.zshrcにClaude Code環境変数ファイルのsource行を追加

### DIFF
--- a/config/zsh/.zshrc
+++ b/config/zsh/.zshrc
@@ -92,5 +92,8 @@ source ${ZDOTDIR}/funcs/peco-src.sh
 # https://github.com/k1LoW/git-wt
 eval "$(git wt --init zsh)"
 
+# Claude Code env
+[ -s "$HOME/.claude/env.sh" ] && . "$HOME/.claude/env.sh"
+
 # local env
 [ -s "${ZDOTDIR}/.zshrc.local" ] && . "${ZDOTDIR}/.zshrc.local"


### PR DESCRIPTION
## Summary

- `~/.claude/env.sh` が存在する場合に読み込む行を `.zshrc` に追加
- `.zshrc.local` より先に source することで、ローカル設定で上書き可能にする

## Test plan

- [ ] `.zshrc` を source して `~/.claude/env.sh` が読み込まれることを確認
- [ ] `~/.claude/env.sh` が存在しない場合でもエラーなく起動することを確認
- [ ] `.zshrc.local` で設定を上書きできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)