### PR TITLE
fix git-mc: resolve stale behind status and force-update tags

### DIFF
--- a/config/git/README.md
+++ b/config/git/README.md
@@ -122,7 +122,7 @@ gh pr edit
 ```bash
 # main worktree に移動してクリーンアップ
 git mc
-# → git switch main && git pull --tags origin HEAD && gh poi
+# → git switch main && git pull --tags --force origin main && gh poi
 ```
 
 `git mc` エイリアスは以下を一括実行する:
@@ -156,5 +156,5 @@ git wt -d <feature-branch>
     basedir = .
 [alias]
     bare-clone = "!f() { ... }; f"  # URL をパースして bare clone + refspec 設定
-    mc = !git switch $(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@') && git pull --tags origin HEAD && gh poi
+    mc = !~/.config/git/git-mc  # main ブランチ切替 + pull --tags --force + gh poi
 ```

--- a/config/git/git-mc
+++ b/config/git/git-mc
@@ -9,5 +9,5 @@ else
   git switch "$main_branch"
 fi
 
-git pull --tags origin HEAD
+git pull --tags --force origin "$main_branch"
 gh poi

--- a/iterm2/com.googlecode.iterm2.plist
+++ b/iterm2/com.googlecode.iterm2.plist
@@ -61,6 +61,18 @@
 			<true/>
 			<key>ASCII Ligatures</key>
 			<false/>
+			<key>AWDS Pane Directory</key>
+			<string></string>
+			<key>AWDS Pane Option</key>
+			<string>Recycle</string>
+			<key>AWDS Tab Directory</key>
+			<string></string>
+			<key>AWDS Tab Option</key>
+			<string>Recycle</string>
+			<key>AWDS Window Directory</key>
+			<string>/Users/masaru_uchida/workspace</string>
+			<key>AWDS Window Option</key>
+			<string>Yes</string>
 			<key>Allow Paste Bracketing</key>
 			<true/>
 			<key>Ambiguous Double Width</key>
@@ -872,7 +884,7 @@
 			<key>Custom Command</key>
 			<string>No</string>
 			<key>Custom Directory</key>
-			<string>Recycle</string>
+			<string>Advanced</string>
 			<key>Default Bookmark</key>
 			<string>No</string>
 			<key>Description</key>
@@ -1305,7 +1317,7 @@
 			<key>Window Type</key>
 			<integer>0</integer>
 			<key>Working Directory</key>
-			<string>/Users/masaru_uchida</string>
+			<string>/Users/masaru_uchida/workspace</string>
 		</dict>
 		<dict>
 			<key>ASCII Anti Aliased</key>
@@ -2559,12 +2571,6 @@
 	</array>
 	<key>OnlyWhenMoreTabs</key>
 	<true/>
-	<key>OpenArrangementAtStartup</key>
-	<false/>
-	<key>OpenBookmark</key>
-	<false/>
-	<key>OpenNoWindowsAtStartup</key>
-	<false/>
 	<key>OpenTmuxWindowsIn</key>
 	<integer>1</integer>
 	<key>PointerActions</key>

--- a/tests/git-mc.bats
+++ b/tests/git-mc.bats
@@ -102,7 +102,7 @@ teardown() {
 # 共通動作
 # =============================================================================
 
-@test "git pull --tags origin HEAD が実行される" {
+@test "git pull --tags --force origin main が実行される" {
   export MOCK_GIT_DIR=".git"
   export MOCK_GIT_COMMON_DIR=".git"
 
@@ -110,7 +110,7 @@ teardown() {
   [ "$status" -eq 0 ]
 
   run cat "$MOCK_LOG"
-  [[ "$output" == *"git pull --tags origin HEAD"* ]]
+  [[ "$output" == *"git pull --tags --force origin main"* ]]
 }
 
 @test "gh poi が実行される" {


### PR DESCRIPTION
## Summary

- `git pull origin HEAD` を `git pull --tags --force origin "$main_branch"` に変更
- `HEAD` refspec では `refs/remotes/origin/main` 追跡 ref が更新されず、何回 pull しても behind が解消されなかった
- `--force` 追加でリモートで移動されたタグもローカルに同期されるようになった
- README.md のドキュメントも現行のスクリプト呼び出しに更新

## Test plan

- [x] `bash -n config/git/git-mc` 構文チェック通過
- [x] `bats tests/git-mc.bats` 全5テスト通過
- [ ] 実リポジトリで `git mc` → `git status` で behind 表示がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)