### PR TITLE
feat(zsh): ~/.claude/bin を PATH に載せる + 溜まっていたローカル設定の取り込み

### DIFF
--- a/config/git/config
+++ b/config/git/config
@@ -16,6 +16,7 @@
 [core]
   excludesfile = ~/.config/git/ignore
   ignorecase = false
+  quotepath = false
 [ghq]
   root = ~/src
 [http]
@@ -39,3 +40,14 @@
   copymodified = true
   hook = test -f .envrc && direnv allow || true
   basedir = ../worktree/{gitroot}
+  nocopy = .venv/
+  nocopy = tmp/
+  nocopy = .worktrees/
+  nocopy = .databricks/
+  nocopy = .pytest_cache/
+  nocopy = .ruff_cache/
+  nocopy = __pycache__/
+  nocopy = node_modules/
+[i18n]
+  commitencoding = utf-8
+  logoutputencoding = utf-8

--- a/config/git/ignore
+++ b/config/git/ignore
@@ -213,3 +213,5 @@ Session.vim
 runn.prof
 **/.claude/settings.local.json
 **/CLAUDE.local.md
+
+**/.claude/.cc-writes/

--- a/config/zsh/.zprofile
+++ b/config/zsh/.zprofile
@@ -46,6 +46,11 @@ export PATH="$(go env GOPATH)/bin:$PATH"
 
 # User-specific paths
 
+# claude-config: `task build:bin` が cmd/ の Go CLI をここへ出力する。
+# hook は同じ実体を絶対パスで起動するので、PATH に載せるのは skill から
+# `cc-dream` のように名前で叩くため。
+export PATH="$HOME/.claude/bin:$PATH"
+
 # Kubernetes tools
 export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
 
@@ -57,4 +62,3 @@ export PATH="$PATH:/Applications/Obsidian.app/Contents/MacOS"
 
 autoload -Uz compinit
 compinit
-

--- a/config/zsh/.zshrc
+++ b/config/zsh/.zshrc
@@ -103,3 +103,4 @@ eval "$(git wt --init zsh)"
 
 test -e "${ZDOTDIR}/.iterm2_shell_integration.zsh" && source "${ZDOTDIR}/.iterm2_shell_integration.zsh" || true
 
+export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
## 概要

主目的は `~/.claude/bin` を PATH に載せること (usadamasa/claude-config#204 の対応)。
併せて、ローカルに未コミットで溜まっていた設定変更をまとめて取り込む。
論点ごとにコミットを分けてあるのでコミット単位で見てもらうのがはやい。

## コミット

| コミット | 内容 |
| --- | --- |
| `feat(zsh): add ~/.claude/bin to PATH` | 本題。下記参照 |
| `chore(zsh): add ~/.local/bin to PATH` | pipx / uv tool の配置先 |
| `chore(git): set quotepath/i18n and expand git-wt nocopy list` | git 設定 |
| `chore(git): ignore .claude/.cc-writes/` | global gitignore |

## `~/.claude/bin` を PATH に載せる理由

claude-config は従来、hook 用の Go バイナリを `dotclaude/bin/` へ、
skill が PATH で叩く `cc-dream` を GOBIN へ、と 2 経路で配布していた。
usadamasa/claude-config#204 でこれを `dotclaude/bin/` (= `~/.claude/bin/`)
の 1 箇所へ統一し、GOBIN への `go install` を廃止した。

- hook は Claude Code プロセスの PATH をそのまま継承し、cmux の named teammate
  では PATH が痩せるため、従来どおり絶対パスで起動する
- skill が名前で叩く CLI (`cc-dream` 等) のために PATH へ載せる。
  同じ実体を指すのでコピーは増えない
- `$(go env GOPATH)/bin` より後に prepend しているため、GOBIN に残った
  旧 `cc-dream` があっても `~/.claude/bin` 側が先勝ちする

依存: usadamasa/claude-config#218 (マージ後に `task build:bin` を回すと実体が揃う)

## 検証

- `task test` (bats 22 件) 全パス
- `editorconfig-checker` (リポジトリ全体) パス
  - `git config` が書いたタブインデントを既存に合わせてスペースへ直してある

🤖 Generated with [Claude Code](https://claude.com/claude-code)
