### PR TITLE
docs(claude): remove content derivable from the codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,21 +2,6 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Repository Architecture
-
-This is a personal dotfiles repository for macOS development environment setup. The structure follows XDG Base Directory standards:
-
-- `config/` - Contains all configuration files organized by tool
-  - `git/` - Git configuration and global gitignore
-  - `npm/` - npm configuration with custom registry and cache settings
-  - `vim/` - Vim configuration with XDG compliance and plugin management
-  - `zsh/` - Zsh configuration with oh-my-zsh integration
-  - `git/git-mc` - 自作 git サブコマンド (シェルスクリプト)
-- `tests/` - bats-core によるシェルスクリプトのテスト (`*.bats`)
-- `Taskfile.yml` - go-task のタスク定義 (セットアップ/テスト/フォーマット)
-- `Brewfile` - Homebrew で管理する依存ツール一覧
-- `.zshenv` - XDG environment variables (symlinked to home directory)
-
 ## Common Commands
 
 ### Initial Setup (Recommended)
@@ -31,83 +16,6 @@ cd ~/src/github.com/usadamasa/dotfile
 # Run initial setup (Homebrew + go-task + complete setup)
 task bootstrap
 ```
-
-### Regular Setup (when go-task is already installed)
-```sh
-# Run complete setup (installs all tools via Homebrew)
-task setup
-
-# Check setup status
-task status
-```
-
-### Tool Management
-```sh
-# Update all Homebrew tools
-brew update && brew upgrade
-
-# List installed Homebrew tools
-brew list
-
-# Search for tools
-brew search <tool-name>
-
-# Check tool info
-brew info <tool-name>
-```
-
-## Modern Installation Process
-
-The repository has been modernized with automated dependency management:
-
-### Tools Used
-- **Homebrew**: Unified package manager for all development tools
-- **go-task**: Modern task runner with dependency management (replaces Makefile)
-
-### Installation Flow
-1. **Bootstrap**: Install Homebrew → install go-task → run automated setup
-2. **Tool Management**: Homebrew installs and manages all development tools
-3. **Task Execution**: go-task handles dependency resolution and idempotent operations
-4. **Configuration**: XDG-compliant directory structure with atomic symlink operations
-5. **Shell Setup**: oh-my-zsh and plugins installed with proper dependency ordering
-6. **Verification**: Built-in status checking and error recovery
-
-### Key Improvements
-- **Task-centric**: All setup logic unified in Taskfile.yml
-- **Homebrew-only**: Simplified tool management with single package manager
-- **Rich Logging**: Emoji-enhanced progress and status reporting
-- **Idempotent**: Safe to run multiple times without side effects
-- **Dependency Resolution**: Tasks run in correct order with explicit dependencies
-- **Error Handling**: Graceful failure recovery and status reporting
-- **Zero External Dependencies**: Only requires Homebrew and go-task
-- **Modular Tasks**: Individual components can be installed/updated separately
-
-## XDG Compliance Tools
-
-### xdg-ninja
-Tool for checking XDG Base Directory compliance and identifying files in $HOME that should be moved to XDG directories.
-
-```sh
-# Check for XDG compliance violations
-xdg-ninja
-
-# Verbose mode - show all checked files
-xdg-ninja --no-skip-ok
-xdg-ninja -v
-
-# Skip files without fixes (default behavior)
-xdg-ninja --skip-ok
-
-# Skip unsupported files
-xdg-ninja --skip-unsupported
-```
-
-**Common XDG Environment Variables:**
-- `XDG_CONFIG_HOME` - User-specific configuration files (`~/.config`)
-- `XDG_DATA_HOME` - User-specific data files (`~/.local/share`)
-- `XDG_STATE_HOME` - User-specific state files (`~/.local/state`)
-- `XDG_CACHE_HOME` - User-specific cache files (`~/.cache`)
-- `XDG_RUNTIME_DIR` - User-specific runtime files (`/run/user/$UID`)
 
 ## テスト・フォーマット
 
@@ -138,11 +46,12 @@ task format  # editorconfig-checker で .editorconfig 準拠をチェック
 
 ### コーディング規約
 
-- 冒頭に `set -euo pipefail` を記述する
 - 変数展開は原則ダブルクォートで囲む (`"$VAR"`)
 - `readonly` と代入は分離する (`VAR=$(cmd); readonly VAR`)
-- `echo` より `printf '%s\n'` を優先する
 - コメント・エラーメッセージは日本語
+
+`set -euo pipefail` と `printf` の使用方針はグローバル CLAUDE.md の
+"Shell Script Quality" に記載。
 
 ## Code Formatting Guidelines
 

--- a/config/git/CLAUDE.md
+++ b/config/git/CLAUDE.md
@@ -7,15 +7,6 @@
 
 Git のグローバル設定ファイル群を管理するディレクトリ。`~/.config/git/` にシンプリンクされ、XDG Base Directory 準拠の配置で動作する。
 
-## ディレクトリ構造
-
-| ファイル | 役割 |
-| --- | --- |
-| `config` | メインの gitconfig。include で他ファイルを読み込む |
-| `gitconfig.local` | デフォルトのユーザー情報 (会社用) |
-| `gitconfig.private` | 個人リポジトリ用ユーザー情報。`includeIf gitdir` で自動適用 |
-| `ignore` | グローバル gitignore |
-
 ## 設定の仕組み
 
 ### ユーザー自動切替
@@ -24,14 +15,6 @@ Git のグローバル設定ファイル群を管理するディレクトリ。`
 
 - **デフォルト**: `gitconfig.local` (環境固有アカウント)
 - **`~/src/github.com/usadamasa/` 配下**: `gitconfig.private` (個人アカウント)
-
-### 主要な設定値
-
-- `pull.rebase = true`, `pull.ff = only` - fast-forward のみの pull + rebase 戦略
-- `merge.conflictStyle = diff3` - 3-way diff でコンフリクト表示
-- `fetch.prune = true` - fetch 時にリモート削除済みブランチを自動削除
-- `ghq.root = ~/src` - ghq のリポジトリルート
-- `init.defaultBranch = main`
 
 ### カスタムエイリアス
 


### PR DESCRIPTION
## Summary

Trim always-loaded `CLAUDE.md` content that a fresh session can reconstruct with a few tool calls (`ls`, reading `Taskfile.yml`, `--help`), so the resident context budget is spent on guidance the code cannot teach.

**`CLAUDE.md`** (170 → 79 lines)

| Removed | Lines | Why |
| --- | --- | --- |
| `## Repository Architecture` | 15 | Directory listing available from `ls` |
| `### Regular Setup` | 9 | `task setup` / `task status` are defined in `Taskfile.yml` |
| `### Tool Management` | 15 | Plain `brew update` / `list` / `search` / `info` invocations |
| `## Modern Installation Process` | 26 | README-style overview of the setup flow |
| `## XDG Compliance Tools` | 27 | `xdg-ninja --help` output plus the XDG standard environment variable table |
| Two coding-convention lines | 2 | `set -euo pipefail` and `printf` over `echo` duplicated the global `CLAUDE.md`; replaced with a pointer to it |

**`config/git/CLAUDE.md`** (54 → 36 lines)

| Removed | Lines | Why |
| --- | --- | --- |
| `## ディレクトリ構造` table | 9 | Derivable from `ls config/git` |
| `### 主要な設定値` | 7 | Copied verbatim from `config` |

**Kept**: shell script conventions (quoting, `readonly` separation, Japanese comments), bats testing practices, the `lint-shell.sh` PostToolUse hook note, long-command formatting rules, `git bare-clone` / `git mc` alias behavior, `gitconfig.private` gotchas, and pointers to the `claude-config` repository.

Estimated saving: ~840 resident tokens per session for `CLAUDE.md`, plus ~110 more when working under `config/git/`.

## Test plan

- [x] `task format` (editorconfig-checker) passes
- [x] Reviewed via `crit` — approved with no comments
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
