### PR TITLE
fix(zsh): stop touching the uv env file on shell startup

### DIFF
--- a/.zshenv
+++ b/.zshenv
@@ -55,6 +55,11 @@ mkdir -p "$PIPX_HOME"
 # Rust
 export CARGO_HOME="$XDG_DATA_HOME"/cargo
 
-# uv
-touch "${XDG_DATA_HOME}/../bin/env"
-source "${XDG_DATA_HOME}/../bin/env"
+# uv and other user-local binaries
+# uv's installer writes ~/.local/bin/env solely to prepend this directory to
+# PATH. Do it directly so no sourcing (and no touch to create a missing file)
+# is needed; touch fails under sandboxed shells that cannot write to ~/.local/bin.
+case ":${PATH}:" in
+    *:"$HOME/.local/bin":*) ;;
+    *) export PATH="$HOME/.local/bin:$PATH" ;;
+esac

--- a/config/zsh/.zshrc
+++ b/config/zsh/.zshrc
@@ -103,4 +103,4 @@ eval "$(git wt --init zsh)"
 
 test -e "${ZDOTDIR}/.iterm2_shell_integration.zsh" && source "${ZDOTDIR}/.iterm2_shell_integration.zsh" || true
 
-export PATH="$HOME/.local/bin:$PATH"
+# PATH for ~/.local/bin is set in ~/.zshenv


### PR DESCRIPTION
## 背景

`~/.zshenv` は uv 用に以下の 2 行を持っていた。

```sh
touch "${XDG_DATA_HOME}/../bin/env"
source "${XDG_DATA_HOME}/../bin/env"
```

`touch` が sandbox 内のシェルで `Operation not permitted` になり、シェル起動のたびに
stderr へ 1 行出る。Claude Code / Codex どちらでも発生し、エージェントの出力が汚れる。

```
touch: /Users/xxx/.local/bin/env: Operation not permitted
```

## 経緯

- 5bb5c58 (2025-07-02) で `source` を追加
- 70dddf3 (2025-07-03) で翌日 `touch` を追加

uv は Brewfile 経由 (Homebrew) で入れているが、Homebrew 版 uv は `~/.local/bin/env` を
作らない (公式インストーラだけが作る)。ファイルが無いと `source` が失敗するため、
それを黙らせるガードとして `touch` が足されたと考えられる。

## 変更

`~/.local/bin/env` の中身は `~/.local/bin` を PATH に prepend するだけなので、
env スクリプトへの依存をやめて `.zshenv` で直接 PATH を設定する。

`config/zsh/.zshrc:106` に同じ `export PATH="$HOME/.local/bin:$PATH"` があり重複して
いたので、`.zshenv` 側に一本化した。`.zshenv` は非対話シェルでも読まれるため、
そちらに置くほうが適切。

## 動作確認

- 非対話 zsh: stderr が空、`~/.local/bin` は PATH に 1 回だけ
- 対話 zsh (`zsh -i`): rc=0、PATH の重複なし、touch のエラーが消えた
- `task format` / `task test` (22 件) 通過

## 補足

対話シェルでは oh-my-zsh のキャッシュ書き込みに由来する別の sandbox エラーが残る。
そちらは usadamasa/claude-config 側の sandbox allowWrite で対応する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)