### PR TITLE
feat(herdr): キーマップ調整と Claude Code のタブ名自動リネーム

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,6 +38,7 @@ tasks:
         echo "zsh設定: $(test -L "$HOME/.config/zsh" && echo '✓' || echo '✗')"
         echo "oh-my-zsh: $(test -d "${XDG_DATA_HOME:-$HOME/.local/share}/oh-my-zsh" && echo '✓' || echo '✗')"
         echo "herdr設定: $(test -L "$HOME/.config/herdr/config.toml" && echo '✓' || echo '✗')"
+        echo "Ghostty設定: $(test -L "$HOME/.config/ghostty/config" && echo '✓' || echo '✗')"
 
   test:
     desc: テストを実行
@@ -67,6 +68,8 @@ tasks:
       - rm -rf "$HOME/.config/zsh" "$HOME/.config/git" "$HOME/.config/vim" "$HOME/.config/npm"
       # ログとセッション状態が残るディレクトリ自体は消さない
       - rm -f "$HOME/.config/herdr/config.toml"
+      - rm -f "$HOME/.config/herdr/herdr-new-agent.sh" "$HOME/.config/herdr/herdr-tab-title.sh"
+      - rm -f "$HOME/.config/ghostty/config"
       - echo "🗑️ 設定をクリーンアップしました"
 
   check-xdg:
@@ -108,9 +111,14 @@ tasks:
       - ln -sfn "{{.DOTFILE_DIR}}/config/vim" "$HOME/.config/"
       - ln -sfn "{{.DOTFILE_DIR}}/config/npm" "$HOME/.config/"
       # herdr は同じディレクトリに socket・ログ・セッション状態を作るため、
-      # ディレクトリごとではなく config.toml だけを symlink する
+      # ディレクトリごとではなくファイル単位で symlink する
       - mkdir -p "$HOME/.config/herdr"
       - ln -sfn "{{.DOTFILE_DIR}}/config/herdr/config.toml" "$HOME/.config/herdr/config.toml"
+      - ln -sfn "{{.DOTFILE_DIR}}/config/herdr/herdr-new-agent.sh" "$HOME/.config/herdr/herdr-new-agent.sh"
+      - ln -sfn "{{.DOTFILE_DIR}}/config/herdr/herdr-tab-title.sh" "$HOME/.config/herdr/herdr-tab-title.sh"
+      # Ghostty も themes などを同じディレクトリに置けるため、config だけを symlink する
+      - mkdir -p "$HOME/.config/ghostty"
+      - ln -sfn "{{.DOTFILE_DIR}}/config/ghostty/config" "$HOME/.config/ghostty/config"
 
   _setup-shell:
     internal: true

--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -1,0 +1,12 @@
+font-size = 16
+font-thicken = true        # 細いフォントを少し太く見せる(macOS のみ)
+adjust-cell-height = 2     # 行間を少し広げて読みやすく
+
+# cmd+←/→ は既定で ^A / ^E を送る。herdr のタブ移動に使うため、
+# Ghostty 側では何もせずアプリへ渡す
+keybind = super+arrow_left=unbind
+keybind = super+arrow_right=unbind
+
+# ctrl+option+n (herdr の新規エージェント起動) が効かない場合に有効化する。
+# option が Alt 扱いになるので、option を使った文字入力はできなくなる
+# macos-option-as-alt = true

--- a/config/herdr/README.md
+++ b/config/herdr/README.md
@@ -1,0 +1,72 @@
+# herdr
+
+[herdr](https://herdr.dev) はコーディングエージェント向けのターミナルワークスペース
+マネージャ。`task setup` で以下が `~/.config/herdr/` へ symlink される。
+
+| ファイル | 役割 |
+| --- | --- |
+| `config.toml` | herdr 本体の設定 (テーマ・UI・キーバインド) |
+| `herdr-new-agent.sh` | ペインを分割して新しいエージェントを起動する |
+| `herdr-tab-title.sh` | Claude Code のプロンプトをタブ名へ反映するフック |
+
+## キーバインド
+
+既定の prefix (`ctrl+b`) 方式は残したまま、直接バインドを追加してある。
+
+| 操作 | キー | prefix 版 |
+| --- | --- | --- |
+| 前のタブ | `cmd` + `←` | `prefix` + `p` |
+| 次のタブ | `cmd` + `→` | `prefix` + `n` |
+| 新しい space (workspace) | `ctrl` + `n` | `prefix` + `shift` + `n` |
+| 新しいタブ | `ctrl` + `shift` + `n` | `prefix` + `c` |
+| 新しい claude エージェント | `ctrl` + `option` + `n` | (なし) |
+
+変更後の反映は再起動不要で、`herdr server reload-config` で足りる。
+
+直接バインドしたキーは herdr が横取りするため、ペイン内のアプリには届かなくなる。
+特に `ctrl+n` は shell の履歴移動や vim の補完で使われるので、影響が大きいと
+感じたら `config.toml` の `new_workspace` から外す。
+
+### ターミナル側の前提
+
+herdr は kitty keyboard protocol を使うため、`cmd` や `ctrl+shift` の
+組み合わせも受け取れる。ただし手前でターミナルが横取りしていると届かない。
+
+Ghostty は既定で `super+arrow_left/right` を `^A` / `^E` に変換するので、
+`config/ghostty/config` で unbind してある。`ctrl+option+n` が効かない場合は
+同ファイルの `macos-option-as-alt` を有効にする。
+
+## タブ名の自動リネーム
+
+`herdr-tab-title.sh` を Claude Code の `UserPromptSubmit` フックに登録すると、
+送信したプロンプトの先頭 20 文字がタブ名になる。
+
+フックの登録先は [claude-config](https://github.com/usadamasa/claude-config) が
+管理する `~/.claude/settings.json`。`hooks.UserPromptSubmit[0].hooks` へ以下を
+追加する。
+
+```json
+{
+  "type": "command",
+  "command": "$HOME/.config/herdr/herdr-tab-title.sh",
+  "timeout": 5
+}
+```
+
+起動中のセッションには、`/hooks` メニューを一度開けば反映される。
+
+### タブの特定方法
+
+`HERDR_TAB_ID` / `HERDR_PANE_ID` は共有デーモン配下で古い値のまま残ることが
+あり、実際のタブとずれる。そのため `herdr api snapshot` へ問い合わせて、
+次の順で対象タブを決めている。
+
+1. herdr が claude 連携フックから受け取ったセッション ID と一致するペイン
+2. セッション ID が未登録で、`cwd` が一致する claude ペインがちょうど 1 つ
+
+どちらにも当てはまらないときは何もしない。誤ったタブを rename しないための
+判断で、worktree などで cwd がずれている場合はタブ名が変わらない。
+
+## 参考
+
+- [herdr でタブタイトルを Claude Code のプロンプトにする](https://tech.anycloud.co.jp/articles/herdr-claude-code-tab-title/)

--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -10,3 +10,28 @@ delivery = "system"
 
 [ui]
 show_agent_labels_on_pane_borders = true
+
+[keys]
+# 既定の prefix 方式は残したまま、よく使う操作にだけ直接バインドを足す。
+# 直接バインドしたキーは herdr が横取りするため、ペイン内のアプリ
+# (shell / vim / エージェント本体) には届かなくなる点に注意。
+
+# タブ移動: cmd + ←/→
+# Ghostty は既定で super+arrow_left/right を ^A / ^E に変換してしまうため、
+# config/ghostty/config 側で unbind してある。
+previous_tab = ["prefix+p", "cmd+left"]
+next_tab = ["prefix+n", "cmd+right"]
+
+# 新しい space (workspace): ctrl + n
+new_workspace = ["prefix+shift+n", "ctrl+n"]
+
+# 新しいタブ: ctrl + shift + n
+new_tab = ["prefix+c", "ctrl+shift+n"]
+
+# 新しいエージェント (claude): ctrl + option + n
+# 現在のペインを分割し、空いたペインで claude を起動する。
+[[keys.command]]
+key = "ctrl+alt+n"
+type = "shell"
+command = "\"$HOME/.config/herdr/herdr-new-agent.sh\" claude"
+description = "start a new claude agent in a sibling pane"

--- a/config/herdr/herdr-new-agent.sh
+++ b/config/herdr/herdr-new-agent.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# herdr のカスタムコマンド ([[keys.command]] type = "shell") から呼ばれ、
+# 現在のペインを分割して新しいエージェントを起動する。
+#
+# herdr は type = "shell" のコマンドを /bin/sh -lc で detached 実行するため、
+# 標準エラー出力はどこにも表示されない。失敗はトーストで通知する。
+set -euo pipefail
+
+KIND="${1:-claude}"
+readonly KIND
+
+HERDR_BIN="${HERDR_BIN_PATH:-herdr}"
+readonly HERDR_BIN
+
+# 失敗をユーザーに見える形で伝える
+notify_error() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  if ! "$HERDR_BIN" notification show "新しい ${KIND} を起動できません" \
+    --body "$message" --sound none >/dev/null 2>&1; then
+    printf '%s\n' "トースト通知にも失敗しました" >&2
+  fi
+}
+
+# 端末のセルは縦長なので、幅が高さのおよそ 2 倍を超えるときだけ横に割る。
+# レイアウトを取得できないときは right にフォールバックする。
+split_direction() {
+  local pane_id="$1"
+  local layout rect width height
+
+  if ! layout=$("$HERDR_BIN" pane layout --pane "$pane_id" 2>&1); then
+    printf '%s\n' "ペインのレイアウト取得に失敗しました: $layout" >&2
+    printf '%s\n' "right"
+    return 0
+  fi
+
+  rect=$(printf '%s' "$layout" | jq -r --arg pane "$pane_id" '
+    .result.layout.panes // []
+    | map(select(.pane_id == $pane))
+    | if length == 1 then "\(.[0].rect.width) \(.[0].rect.height)" else empty end
+  ')
+  if [ -z "$rect" ]; then
+    printf '%s\n' "right"
+    return 0
+  fi
+
+  width=${rect%% *}
+  height=${rect##* }
+  if [ "$width" -gt $((height * 2)) ]; then
+    printf '%s\n' "right"
+  else
+    printf '%s\n' "down"
+  fi
+}
+
+main() {
+  local pane_id cwd direction response new_pane agent_name
+
+  pane_id="${HERDR_ACTIVE_PANE_ID:-}"
+  if [ -z "$pane_id" ]; then
+    notify_error "HERDR_ACTIVE_PANE_ID が空です"
+    exit 1
+  fi
+  cwd="${HERDR_ACTIVE_PANE_CWD:-$HOME}"
+
+  direction=$(split_direction "$pane_id")
+
+  if ! response=$("$HERDR_BIN" pane split \
+    --pane "$pane_id" \
+    --direction "$direction" \
+    --cwd "$cwd" \
+    --focus 2>&1); then
+    notify_error "ペインの分割に失敗しました: $response"
+    exit 1
+  fi
+
+  new_pane=$(printf '%s' "$response" | jq -r '.result.pane.pane_id // empty')
+  if [ -z "$new_pane" ]; then
+    notify_error "分割したペインの ID を取得できません: $response"
+    exit 1
+  fi
+
+  # 同一タブ内で名前が衝突しないよう、ペイン ID の末尾を付ける
+  agent_name="${KIND}-${new_pane##*:}"
+
+  if ! response=$("$HERDR_BIN" agent start "$agent_name" \
+    --kind "$KIND" \
+    --pane "$new_pane" 2>&1); then
+    notify_error "${KIND} の起動に失敗しました: $response"
+    exit 1
+  fi
+}
+
+main "$@"

--- a/config/herdr/herdr-tab-title.sh
+++ b/config/herdr/herdr-tab-title.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Claude Code の UserPromptSubmit フックとして動き、送信したプロンプトの先頭を
+# herdr のタブ名に反映する。
+#
+# 制約:
+#   - UserPromptSubmit の標準出力はモデルのコンテキストへ注入されるため、
+#     このスクリプトは標準出力へ一切書かない。診断は標準エラーへ出す。
+#   - フックの失敗でプロンプト送信を妨げないよう、常に exit 0 で終える。
+#     このため `set -e` は使わず、失敗は個別に捕捉して標準エラーへ記録する。
+set -uo pipefail
+
+# タブ名の最大文字数 (超過分は末尾を … に置き換える)
+MAX_TITLE_CHARS=20
+readonly MAX_TITLE_CHARS
+
+# タブ名にするプロンプトの先頭を取り出す。空白は 1 個に潰す。
+extract_title() {
+  jq -r --argjson max "$MAX_TITLE_CHARS" '
+    (.prompt // "")
+    | gsub("\\s+"; " ")
+    | sub("^ +"; "")
+    | sub(" +$"; "")
+    | if length == 0 then empty
+      elif length > $max then .[0:($max - 1)] + "…"
+      else .
+      end
+  '
+}
+
+# どのタブを rename するかを決める。曖昧なときは何も返さない。
+#
+#   1. herdr が claude 連携フックから受け取ったセッション ID と一致するペイン
+#   2. セッション ID が未登録で、cwd が一致する claude ペインがちょうど 1 つ
+#
+# HERDR_TAB_ID / HERDR_PANE_ID は共有デーモン配下で古い値のまま残ることがあり、
+# 実際のタブとずれるため使わない。
+resolve_tab_id() {
+  local session_id="$1"
+  local cwd="$2"
+
+  jq -r --arg sid "$session_id" --arg cwd "$cwd" '
+    (.result.snapshot.panes // []) as $panes
+    | ($panes | map(select(
+        ($sid | length) > 0 and ((.agent_session.value? // "") == $sid)
+      ))) as $exact
+    | if ($exact | length) > 0 then
+        $exact[0].tab_id
+      else
+        ($panes | map(select(
+          .agent == "claude"
+          and (.agent_session == null)
+          and ($cwd | length) > 0
+          and ((.cwd == $cwd) or (.foreground_cwd == $cwd))
+        ))) as $by_cwd
+        | if ($by_cwd | length) == 1 then $by_cwd[0].tab_id else empty end
+      end
+  '
+}
+
+main() {
+  local input title session_id cwd snapshot tab_id
+
+  input=$(cat)
+
+  # herdr のペインの外や、必要なコマンドが無い環境では何もしない
+  [ "${HERDR_ENV:-}" = "1" ] || return 0
+  command -v herdr >/dev/null 2>&1 || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+
+  # サブエージェントのプロンプトはタブ名に反映しない
+  if [ -n "$(printf '%s' "$input" | jq -r '.agent_id // empty')" ]; then
+    return 0
+  fi
+
+  title=$(printf '%s' "$input" | extract_title)
+  [ -n "$title" ] || return 0
+
+  session_id=$(printf '%s' "$input" | jq -r '.session_id // empty')
+  cwd=$(printf '%s' "$input" | jq -r '.cwd // empty')
+
+  if ! snapshot=$(herdr api snapshot 2>&1); then
+    printf '%s\n' "herdr api snapshot に失敗しました: $snapshot" >&2
+    return 0
+  fi
+
+  tab_id=$(printf '%s' "$snapshot" | resolve_tab_id "$session_id" "$cwd")
+  if [ -z "$tab_id" ]; then
+    printf '%s\n' "このセッションに対応する herdr のタブを特定できません" >&2
+    return 0
+  fi
+
+  local result
+  if ! result=$(herdr tab rename "$tab_id" "$title" 2>&1); then
+    printf '%s\n' "タブ名の変更に失敗しました: $result" >&2
+    return 0
+  fi
+}
+
+main "$@"
+exit 0

--- a/tests/herdr-new-agent.bats
+++ b/tests/herdr-new-agent.bats
@@ -1,0 +1,148 @@
+#!/usr/bin/env bats
+# herdr-new-agent.sh のテスト
+# ペイン分割の向きの判定と、エージェント起動までの呼び出しを検証
+
+SCRIPT="$BATS_TEST_DIRNAME/../config/herdr/herdr-new-agent.sh"
+
+setup() {
+  export MOCK_LOG="$BATS_TEST_TMPDIR/calls.log"
+
+  MOCK_BIN="$BATS_TEST_TMPDIR/mock-bin"
+  mkdir -p "$MOCK_BIN"
+
+  # herdr モック: 呼び出しを記録しつつ、API と同じ形の JSON を返す
+  cat > "$MOCK_BIN/herdr" <<'MOCK'
+#!/usr/bin/env bash
+printf 'CALLED: %s\n' "$*" >> "$MOCK_LOG"
+case "$1 $2" in
+  "pane layout")
+    printf '{"result":{"layout":{"panes":[{"pane_id":"%s","rect":{"width":%s,"height":%s}}]}}}\n' \
+      "${MOCK_PANE_ID:-wA:p1}" "${MOCK_PANE_WIDTH:-135}" "${MOCK_PANE_HEIGHT:-42}"
+    ;;
+  "pane split")
+    if [ "${MOCK_SPLIT_FAILS:-0}" = "1" ]; then
+      printf '{"error":{"code":"pane_not_found"}}\n' >&2
+      exit 1
+    fi
+    printf '{"result":{"pane":{"pane_id":"wA:p2"}}}\n'
+    ;;
+esac
+MOCK
+  chmod +x "$MOCK_BIN/herdr"
+
+  export PATH="$MOCK_BIN:$PATH"
+  export HERDR_ACTIVE_PANE_ID="wA:p1"
+  export HERDR_ACTIVE_PANE_CWD="/repo/a"
+}
+
+# =============================================================================
+# 構文チェック
+# =============================================================================
+
+@test "スクリプトの構文が正しい" {
+  run bash -n "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# 分割の向き
+# =============================================================================
+
+@test "横長のペインは right に分割する" {
+  export MOCK_PANE_WIDTH=135
+  export MOCK_PANE_HEIGHT=42
+
+  run bash "$SCRIPT" claude
+  [ "$status" -eq 0 ]
+
+  run cat "$MOCK_LOG"
+  [[ "$output" == *"--direction right"* ]]
+}
+
+@test "正方形に近いペインは down に分割する" {
+  export MOCK_PANE_WIDTH=80
+  export MOCK_PANE_HEIGHT=42
+
+  run bash "$SCRIPT" claude
+  [ "$status" -eq 0 ]
+
+  run cat "$MOCK_LOG"
+  [[ "$output" == *"--direction down"* ]]
+}
+
+@test "レイアウトを取得できないときは right にフォールバックする" {
+  cat > "$MOCK_BIN/herdr" <<'MOCK'
+#!/usr/bin/env bash
+printf 'CALLED: %s\n' "$*" >> "$MOCK_LOG"
+case "$1 $2" in
+  "pane layout")
+    printf 'server unavailable\n' >&2
+    exit 1
+    ;;
+  "pane split")
+    printf '{"result":{"pane":{"pane_id":"wA:p2"}}}\n'
+    ;;
+esac
+MOCK
+  chmod +x "$MOCK_BIN/herdr"
+
+  run bash "$SCRIPT" claude
+  [ "$status" -eq 0 ]
+
+  run cat "$MOCK_LOG"
+  [[ "$output" == *"--direction right"* ]]
+}
+
+# =============================================================================
+# エージェントの起動
+# =============================================================================
+
+@test "分割したペインで指定した種類のエージェントを起動する" {
+  run bash "$SCRIPT" claude
+  [ "$status" -eq 0 ]
+
+  run cat "$MOCK_LOG"
+  [[ "$output" == *"agent start claude-p2 --kind claude --pane wA:p2"* ]]
+}
+
+@test "種類を省略すると claude を起動する" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  run cat "$MOCK_LOG"
+  [[ "$output" == *"--kind claude"* ]]
+}
+
+@test "呼び出し元ペインの cwd を引き継ぐ" {
+  run bash "$SCRIPT" claude
+  [ "$status" -eq 0 ]
+
+  run cat "$MOCK_LOG"
+  [[ "$output" == *"--cwd /repo/a"* ]]
+}
+
+# =============================================================================
+# 異常系
+# =============================================================================
+
+@test "HERDR_ACTIVE_PANE_ID が空なら通知して失敗する" {
+  export HERDR_ACTIVE_PANE_ID=""
+
+  run bash "$SCRIPT" claude
+  [ "$status" -eq 1 ]
+
+  run cat "$MOCK_LOG"
+  [[ "$output" == *"notification show"* ]]
+  [[ "$output" != *"pane split"* ]]
+}
+
+@test "ペインの分割に失敗したら通知して失敗する" {
+  export MOCK_SPLIT_FAILS=1
+
+  run bash "$SCRIPT" claude
+  [ "$status" -eq 1 ]
+
+  run cat "$MOCK_LOG"
+  [[ "$output" == *"notification show"* ]]
+  [[ "$output" != *"agent start"* ]]
+}

--- a/tests/herdr-tab-title.bats
+++ b/tests/herdr-tab-title.bats
@@ -1,0 +1,221 @@
+#!/usr/bin/env bats
+# herdr-tab-title.sh のテスト
+# Claude Code のフック入力から、どの herdr タブを rename するかの判定を検証
+
+SCRIPT="$BATS_TEST_DIRNAME/../config/herdr/herdr-tab-title.sh"
+
+setup() {
+  export MOCK_LOG="$BATS_TEST_TMPDIR/calls.log"
+  export SNAPSHOT_FILE="$BATS_TEST_TMPDIR/snapshot.json"
+
+  MOCK_BIN="$BATS_TEST_TMPDIR/mock-bin"
+  mkdir -p "$MOCK_BIN"
+
+  # herdr モック: api snapshot はフィクスチャを返し、tab rename は記録する
+  cat > "$MOCK_BIN/herdr" <<'MOCK'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "api snapshot")
+    cat "$SNAPSHOT_FILE"
+    ;;
+  "tab rename")
+    shift 2
+    printf 'CALLED: tab rename %s\n' "$*" >> "$MOCK_LOG"
+    ;;
+  *)
+    printf 'CALLED: %s\n' "$*" >> "$MOCK_LOG"
+    ;;
+esac
+MOCK
+  chmod +x "$MOCK_BIN/herdr"
+
+  export PATH="$MOCK_BIN:$PATH"
+  export HERDR_ENV=1
+
+  # 既定のスナップショット:
+  #   wA:p1 … セッション ID 登録済み
+  #   wB:p1 … セッション ID 未登録
+  cat > "$SNAPSHOT_FILE" <<'JSON'
+{
+  "result": {
+    "snapshot": {
+      "panes": [
+        {
+          "agent": "claude",
+          "pane_id": "wA:p1",
+          "tab_id": "wA:t1",
+          "cwd": "/repo/a",
+          "foreground_cwd": "/repo/a",
+          "agent_session": {
+            "source": "herdr:claude",
+            "agent": "claude",
+            "kind": "session_id",
+            "value": "sess-aaa"
+          }
+        },
+        {
+          "agent": "claude",
+          "pane_id": "wB:p1",
+          "tab_id": "wB:t1",
+          "cwd": "/repo/b",
+          "foreground_cwd": "/repo/b",
+          "agent_session": null
+        }
+      ]
+    }
+  }
+}
+JSON
+}
+
+# フック入力の JSON を組み立てる
+hook_input() {
+  local prompt="$1" session_id="${2:-}" cwd="${3:-}" agent_id="${4:-}"
+  jq -n \
+    --arg prompt "$prompt" \
+    --arg session_id "$session_id" \
+    --arg cwd "$cwd" \
+    --arg agent_id "$agent_id" \
+    '{hook_event_name: "UserPromptSubmit", prompt: $prompt, session_id: $session_id, cwd: $cwd}
+    + (if ($agent_id | length) > 0 then {agent_id: $agent_id} else {} end)'
+}
+
+# =============================================================================
+# 構文チェック
+# =============================================================================
+
+@test "スクリプトの構文が正しい" {
+  run bash -n "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# タブの特定
+# =============================================================================
+
+@test "セッション ID が一致するペインのタブを rename する" {
+  run bash "$SCRIPT" <<< "$(hook_input "請求書の集計" "sess-aaa" "/repo/a")"
+  [ "$status" -eq 0 ]
+
+  run cat "$MOCK_LOG"
+  [[ "$output" == *"tab rename wA:t1 請求書の集計"* ]]
+}
+
+@test "セッション ID 未登録でも cwd が一意に一致すれば rename する" {
+  run bash "$SCRIPT" <<< "$(hook_input "テストを直す" "sess-unknown" "/repo/b")"
+  [ "$status" -eq 0 ]
+
+  run cat "$MOCK_LOG"
+  [[ "$output" == *"tab rename wB:t1 テストを直す"* ]]
+}
+
+@test "cwd が一致しなければ rename しない" {
+  run bash "$SCRIPT" <<< "$(hook_input "テストを直す" "sess-unknown" "/repo/zzz")"
+  [ "$status" -eq 0 ]
+  [ ! -f "$MOCK_LOG" ]
+}
+
+@test "cwd が一致する候補が複数あれば rename しない" {
+  cat > "$SNAPSHOT_FILE" <<'JSON'
+{
+  "result": {
+    "snapshot": {
+      "panes": [
+        {"agent": "claude", "pane_id": "wA:p1", "tab_id": "wA:t1",
+          "cwd": "/repo/a", "foreground_cwd": "/repo/a", "agent_session": null},
+        {"agent": "claude", "pane_id": "wA:p2", "tab_id": "wA:t2",
+          "cwd": "/repo/a", "foreground_cwd": "/repo/a", "agent_session": null}
+      ]
+    }
+  }
+}
+JSON
+
+  run bash "$SCRIPT" <<< "$(hook_input "テストを直す" "sess-unknown" "/repo/a")"
+  [ "$status" -eq 0 ]
+  [ ! -f "$MOCK_LOG" ]
+}
+
+@test "claude 以外のエージェントのペインは cwd 一致でも対象にしない" {
+  cat > "$SNAPSHOT_FILE" <<'JSON'
+{
+  "result": {
+    "snapshot": {
+      "panes": [
+        {"agent": "codex", "pane_id": "wA:p1", "tab_id": "wA:t1",
+          "cwd": "/repo/a", "foreground_cwd": "/repo/a", "agent_session": null}
+      ]
+    }
+  }
+}
+JSON
+
+  run bash "$SCRIPT" <<< "$(hook_input "テストを直す" "sess-unknown" "/repo/a")"
+  [ "$status" -eq 0 ]
+  [ ! -f "$MOCK_LOG" ]
+}
+
+# =============================================================================
+# タブ名の整形
+# =============================================================================
+
+@test "20 文字を超えるプロンプトは末尾を … に置き換える" {
+  run bash "$SCRIPT" <<< "$(hook_input "あいうえおかきくけこさしすせそたちつてとなにぬねの" "sess-aaa" "/repo/a")"
+  [ "$status" -eq 0 ]
+
+  run cat "$MOCK_LOG"
+  [[ "$output" == *"tab rename wA:t1 あいうえおかきくけこさしすせそたちつて…"* ]]
+}
+
+@test "改行と連続する空白は 1 個の空白に潰す" {
+  run bash "$SCRIPT" <<< "$(hook_input $'テストを\n\n  直す' "sess-aaa" "/repo/a")"
+  [ "$status" -eq 0 ]
+
+  run cat "$MOCK_LOG"
+  [[ "$output" == *"tab rename wA:t1 テストを 直す"* ]]
+}
+
+@test "空白だけのプロンプトでは rename しない" {
+  run bash "$SCRIPT" <<< "$(hook_input $'  \n  ' "sess-aaa" "/repo/a")"
+  [ "$status" -eq 0 ]
+  [ ! -f "$MOCK_LOG" ]
+}
+
+# =============================================================================
+# ガード節
+# =============================================================================
+
+@test "HERDR_ENV が 1 でなければ何もしない" {
+  unset HERDR_ENV
+
+  run bash "$SCRIPT" <<< "$(hook_input "請求書の集計" "sess-aaa" "/repo/a")"
+  [ "$status" -eq 0 ]
+  [ ! -f "$MOCK_LOG" ]
+}
+
+@test "サブエージェントのプロンプトでは rename しない" {
+  run bash "$SCRIPT" <<< "$(hook_input "請求書の集計" "sess-aaa" "/repo/a" "agent-1")"
+  [ "$status" -eq 0 ]
+  [ ! -f "$MOCK_LOG" ]
+}
+
+# =============================================================================
+# 出力
+# =============================================================================
+
+@test "標準出力には何も書かない" {
+  output=$(bash "$SCRIPT" 2>/dev/null <<< "$(hook_input "請求書の集計" "sess-aaa" "/repo/a")")
+  [ -z "$output" ]
+}
+
+@test "herdr api snapshot が失敗しても exit 0 で終わる" {
+  cat > "$MOCK_BIN/herdr" <<'MOCK'
+#!/usr/bin/env bash
+printf 'server unavailable\n' >&2
+exit 1
+MOCK
+  chmod +x "$MOCK_BIN/herdr"
+
+  run bash "$SCRIPT" <<< "$(hook_input "請求書の集計" "sess-aaa" "/repo/a")"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## 概要

[herdr でタブタイトルを Claude Code のプロンプトにする](https://tech.anycloud.co.jp/articles/herdr-claude-code-tab-title/) を参考に、herdr のキーマップを調整し、タブ名の自動リネームを追加する。

## キーバインド

既定の prefix (`ctrl+b`) 方式は残したまま、直接バインドを追加した。

| 操作 | キー | prefix 版 |
| --- | --- | --- |
| 前のタブ | `cmd` + `←` | `prefix` + `p` |
| 次のタブ | `cmd` + `→` | `prefix` + `n` |
| 新しい space (workspace) | `ctrl` + `n` | `prefix` + `shift` + `n` |
| 新しいタブ | `ctrl` + `shift` + `n` | `prefix` + `c` |
| 新しい claude エージェント | `ctrl` + `option` + `n` | (なし) |

`new_agent` に相当する組み込みアクションは herdr 0.8.0 に無いため、`[[keys.command]]` から `herdr-new-agent.sh` を呼び、`pane split` → `agent start` の順で起動する。分割の向きはペインの縦横比から決める。

## Ghostty の設定を管理下に置いた

Ghostty は既定で `super+arrow_left/right` を `^A` / `^E` に変換するため、そのままだと `cmd` + `←/→` が herdr まで届かない。`~/.config/ghostty/config` を dotfile 管理にして unbind した。既存の 3 行はそのまま持ち込んである。

`ctrl+option+n` が効かない場合に備えて `macos-option-as-alt` をコメントで用意した。有効にすると option を使った文字入力ができなくなるので、既定では無効のまま。

## タブ名の自動リネーム

`herdr-tab-title.sh` は Claude Code の `UserPromptSubmit` フックとして動き、送信したプロンプトの先頭 20 文字をタブ名にする。

対象タブは `herdr api snapshot` から次の順で決める。`HERDR_TAB_ID` / `HERDR_PANE_ID` は共有デーモン配下で古い値のまま残り、実際のタブとずれるため使わない (このリポジトリでの作業中にも実際にずれていた)。

1. herdr が claude 連携フックから受け取ったセッション ID と一致するペイン
2. セッション ID が未登録で、`cwd` が一致する claude ペインがちょうど 1 つ

どちらにも当てはまらなければ何もしない。誤ったタブを rename しないための判断。

参考記事は python3 を使っているが、ここでは jq に置き換えた。

## 残作業

フックの登録先 `~/.claude/settings.json` は claude-config リポジトリの管理下にあり、このリポジトリからは変更できない。手順は `config/herdr/README.md` に書いた。

## テスト

- `bats tests/herdr-tab-title.bats tests/herdr-new-agent.bats` … 22 件すべて green
- `shellcheck` … 指摘なし
- `editorconfig-checker` … 指摘なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
