### PR TITLE
feat(ghostty): cmd 系キーを herdr へ委譲する

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -50,29 +50,40 @@ clipboard-read = allow
 clipboard-write = allow
 
 #
-# ペイン操作
+# ペイン操作 (herdr へ委譲)
 #
-# 【重要】Cmd+Enter で「下に」分割
-keybind = cmd+enter=new_split:down
+# Ghostty は herdr を載せる器に徹する。ペイン / タブ / workspace の生成と
+# 移動はすべて herdr 側で行うので、cmd 系のキーは Ghostty で消費せず
+# kitty keyboard protocol の CSI-u シーケンスとして herdr へ送る。
+#
+# csi:<code>;<mod>u の <code> はキーの Unicode コードポイント
+# (enter=13, n=110, t=116, w=119)、<mod> は 1 + shift(1) + alt(2) + ctrl(4)
+# + super(8)。つまり cmd = 9、cmd+shift = 10。矢印は CSI 1;<mod>A/B/C/D。
+#
+# unbind でも Ghostty が super 付きキーを CSI-u に符号化するが、
+# macOS 側で cmd+矢印などを横取りされた実績があるため、送るバイト列を
+# ここで固定する。herdr 側の受け口は config/herdr/config.toml。
 
-# Cmd+Shift+Enter で「右に」分割
-keybind = cmd+shift+enter=new_split:right
+# Cmd+Enter で「下に」分割 / Cmd+Shift+Enter で「右に」分割
+keybind = cmd+enter=csi:13;9u
+keybind = cmd+shift+enter=csi:13;10u
 
-# Cmd + 矢印キー で分割した画面を「移動」
-keybind = cmd+left=goto_split:left
-keybind = cmd+right=goto_split:right
-keybind = cmd+up=goto_split:top
-keybind = cmd+down=goto_split:bottom
+# Cmd+N で新しい workspace / Cmd+T で新しいタブ
+keybind = cmd+n=csi:110;9u
+keybind = cmd+t=csi:116;9u
 
-# Cmd + Shift + 矢印キー で分割サイズを「調整」
-keybind = cmd+shift+left=resize_split:left,20
-keybind = cmd+shift+right=resize_split:right,20
-keybind = cmd+shift+up=resize_split:up,20
-keybind = cmd+shift+down=resize_split:down,20
+# Cmd+W で現在のペインを閉じる (ウィンドウを閉じるのは Cmd+Shift+W)
+keybind = cmd+w=csi:119;9u
 
-# Cmd + W で現在の「ペイン（分割）」を閉じる
-# （デフォルトだとウィンドウごと閉じてしまうことがあるため、ペインを閉じる設定を優先）
-keybind = cmd+w=close_surface
+# Cmd + 矢印キー でペイン間を「移動」
+keybind = cmd+left=csi:1;9D
+keybind = cmd+right=csi:1;9C
+keybind = cmd+up=csi:1;9A
+keybind = cmd+down=csi:1;9B
+
+# ペインのリサイズは herdr の resize mode (prefix + r) を使う。
+# herdr に方向指定のリサイズを直接バインドする口がないため、
+# Ghostty 側の resize_split は持たない。
 
 #
 # その他

--- a/config/herdr/README.md
+++ b/config/herdr/README.md
@@ -17,26 +17,35 @@ Claude Code のプロンプトをタブ名へ反映するフックは
 
 | 操作 | キー | prefix 版 |
 | --- | --- | --- |
-| 前のタブ | `cmd` + `←` | `prefix` + `p` |
-| 次のタブ | `cmd` + `→` | `prefix` + `n` |
-| 新しい space (workspace) | `ctrl` + `n` | `prefix` + `shift` + `n` |
-| 新しいタブ | `ctrl` + `shift` + `n` | `prefix` + `c` |
+| ペインを下に分割 | `cmd` + `enter` | `prefix` + `-` |
+| ペインを右に分割 | `cmd` + `shift` + `enter` | `prefix` + `v` |
+| ペイン間の移動 | `cmd` + `←↓↑→` | `prefix` + `h/j/k/l` |
+| ペインを閉じる | `cmd` + `w` | `prefix` + `x` |
+| 新しい space (workspace) | `cmd` + `n` (`ctrl` + `n`) | `prefix` + `shift` + `n` |
+| 新しいタブ | `cmd` + `t` | `prefix` + `c` |
+| 前のタブ | `shift` + `←` / `↑` | `prefix` + `p` |
+| 次のタブ | `shift` + `→` / `↓` | `prefix` + `n` |
 | 新しい claude エージェント | `ctrl` + `option` + `n` | (なし) |
+| ペインのリサイズ | (なし) | `prefix` + `r` |
 
 変更後の反映は再起動不要で、`herdr server reload-config` で足りる。
 
 直接バインドしたキーは herdr が横取りするため、ペイン内のアプリには届かなくなる。
-特に `ctrl+n` は shell の履歴移動や vim の補完で使われるので、影響が大きいと
-感じたら `config.toml` の `new_workspace` から外す。
+特に `ctrl+n` は shell の履歴移動や vim の補完で使われる。`cmd+n` が安定して
+効くなら `config.toml` の `new_workspace` から外してよい。
 
 ### ターミナル側の前提
 
 herdr は kitty keyboard protocol を使うため、`cmd` や `ctrl+shift` の
 組み合わせも受け取れる。ただし手前でターミナルが横取りしていると届かない。
 
-Ghostty は既定で `super+arrow_left/right` を `^A` / `^E` に変換するので、
-`config/ghostty/config` で unbind してある。`ctrl+option+n` が効かない場合は
-同ファイルの `macos-option-as-alt` を有効にする。
+Ghostty は `cmd` 系のキー (`cmd+enter` / `cmd+n` / `cmd+t` / `cmd+w` /
+`cmd+矢印`) を既定で自分のタブ・ウィンドウ操作に使うため、
+`config/ghostty/config` で CSI-u シーケンス (`csi:13;9u` など) に付け替えて
+herdr へ転送している。キーを増やすときは両方のファイルを対で更新する。
+
+`ctrl+option+n` が効かない場合は `config/ghostty/config` の
+`macos-option-as-alt` を有効にする。
 
 ## 参考
 

--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -22,12 +22,33 @@ prompt_new_tab_name = false
 # 直接バインドしたキーは herdr が横取りするため、ペイン内のアプリ
 # (shell / vim / エージェント本体) には届かなくなる点に注意。
 
-# タブ移動: cmd + ←/→
+# タブ移動: shift + ←/→ (↑/↓ も同義)
 previous_tab = ["shift+left", "shift+up"]
 next_tab = ["shift+right", "shift+down"]
 
-# 新しい space (workspace): ctrl + n
-new_workspace = ["prefix+shift+n", "ctrl+n"]
+# ここから下の cmd 系は Ghostty が CSI-u で転送してくるキー。
+# config/ghostty/config の keybind = cmd+... = csi:... と対で維持する。
+
+# ペイン分割: cmd + enter で下、cmd + shift + enter で右
+split_horizontal = ["prefix+minus", "cmd+enter"]
+split_vertical = ["prefix+v", "cmd+shift+enter"]
+
+# ペイン移動: cmd + 矢印
+focus_pane_left = ["prefix+h", "cmd+left"]
+focus_pane_down = ["prefix+j", "cmd+down"]
+focus_pane_up = ["prefix+k", "cmd+up"]
+focus_pane_right = ["prefix+l", "cmd+right"]
+
+# ペインを閉じる: cmd + w
+close_pane = ["prefix+x", "cmd+w"]
+
+# 新しい space (workspace): cmd + n
+# ctrl + n は cmd + n が使えなかった頃の名残。shell の履歴移動を奪うので、
+# cmd + n が安定して効くなら外してよい。
+new_workspace = ["prefix+shift+n", "ctrl+n", "cmd+n"]
+
+# 新しいタブ: cmd + t
+new_tab = ["prefix+c", "cmd+t"]
 
 # 新しいエージェント (claude): ctrl + option + n
 # 現在のペインを分割し、空いたペインで claude を起動する。

--- a/tests/ghostty-herdr-keys.bats
+++ b/tests/ghostty-herdr-keys.bats
@@ -1,0 +1,105 @@
+#!/usr/bin/env bats
+# Ghostty と herdr のキーバインド連携のテスト
+#
+# Ghostty は cmd 系のキーを自分で消費せず、kitty keyboard protocol の
+# CSI-u シーケンスとして herdr へ転送する。両ファイルの対応が崩れると
+# キーがどこにも届かなくなるため、対になっていることを検証する。
+
+GHOSTTY_CONFIG="$BATS_TEST_DIRNAME/../config/ghostty/config"
+HERDR_CONFIG="$BATS_TEST_DIRNAME/../config/herdr/config.toml"
+
+# Ghostty の keybind から転送先のシーケンスを取り出す
+ghostty_action() {
+  local trigger="$1"
+  grep -E "^keybind = ${trigger}=" "$GHOSTTY_CONFIG" | sed -E 's/^keybind = [^=]+=//'
+}
+
+# herdr の [keys] で指定のキーがどのアクションに割り当たっているか
+herdr_action_for_key() {
+  local key="$1"
+  grep -E "^[a-z_]+ = \[.*\"${key}\".*\]" "$HERDR_CONFIG" | sed -E 's/ =.*//'
+}
+
+# =============================================================================
+# Ghostty 側: cmd 系は CSI-u 転送に徹する
+# =============================================================================
+
+@test "cmd 系のキーは Ghostty 自身のペイン・タブ操作に使われない" {
+  run grep -nE '^keybind = cmd\+.*=(new_split|new_tab|new_window|goto_split|resize_split|close_surface)' "$GHOSTTY_CONFIG"
+  [ "$status" -ne 0 ]
+}
+
+@test "cmd+enter は下分割用の CSI-u を送る" {
+  # 13 = enter の Unicode コードポイント、9 = 1 + super(8)
+  [ "$(ghostty_action 'cmd\+enter')" = 'csi:13;9u' ]
+}
+
+@test "cmd+shift+enter は右分割用の CSI-u を送る" {
+  # 10 = 1 + shift(1) + super(8)
+  [ "$(ghostty_action 'cmd\+shift\+enter')" = 'csi:13;10u' ]
+}
+
+@test "cmd+n は workspace 生成用の CSI-u を送る" {
+  # 110 = n の Unicode コードポイント
+  [ "$(ghostty_action 'cmd\+n')" = 'csi:110;9u' ]
+}
+
+@test "cmd+矢印はペイン移動用の CSI-u を送る" {
+  [ "$(ghostty_action 'cmd\+left')" = 'csi:1;9D' ]
+  [ "$(ghostty_action 'cmd\+right')" = 'csi:1;9C' ]
+  [ "$(ghostty_action 'cmd\+up')" = 'csi:1;9A' ]
+  [ "$(ghostty_action 'cmd\+down')" = 'csi:1;9B' ]
+}
+
+# =============================================================================
+# herdr 側: 転送されたキーを受け取るバインドがある
+# =============================================================================
+
+@test "cmd+enter が herdr の下分割に割り当たっている" {
+  [ "$(herdr_action_for_key 'cmd\+enter')" = "split_horizontal" ]
+}
+
+@test "cmd+shift+enter が herdr の右分割に割り当たっている" {
+  [ "$(herdr_action_for_key 'cmd\+shift\+enter')" = "split_vertical" ]
+}
+
+@test "cmd+n が herdr の workspace 生成に割り当たっている" {
+  [ "$(herdr_action_for_key 'cmd\+n')" = "new_workspace" ]
+}
+
+@test "cmd+t が herdr のタブ生成に割り当たっている" {
+  [ "$(herdr_action_for_key 'cmd\+t')" = "new_tab" ]
+}
+
+@test "cmd+w が herdr のペイン close に割り当たっている" {
+  [ "$(herdr_action_for_key 'cmd\+w')" = "close_pane" ]
+}
+
+@test "cmd+矢印が herdr のペイン移動に割り当たっている" {
+  [ "$(herdr_action_for_key 'cmd\+left')" = "focus_pane_left" ]
+  [ "$(herdr_action_for_key 'cmd\+down')" = "focus_pane_down" ]
+  [ "$(herdr_action_for_key 'cmd\+up')" = "focus_pane_up" ]
+  [ "$(herdr_action_for_key 'cmd\+right')" = "focus_pane_right" ]
+}
+
+# =============================================================================
+# 設定ファイル自体の妥当性 (ツールがある環境でのみ)
+# =============================================================================
+
+@test "herdr が config.toml を受け付ける" {
+  if ! command -v herdr > /dev/null; then
+    skip "herdr がインストールされていない"
+  fi
+  HERDR_CONFIG_PATH="$HERDR_CONFIG" run herdr config check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ok"* ]]
+}
+
+@test "Ghostty が config を受け付ける" {
+  local ghostty=/Applications/Ghostty.app/Contents/MacOS/ghostty
+  if [ ! -x "$ghostty" ]; then
+    skip "Ghostty がインストールされていない"
+  fi
+  run "$ghostty" +validate-config --config-file="$GHOSTTY_CONFIG"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## 概要

Ghostty (`command = herdr`) が cmd 系のキーを自分で消費してしまい、`cmd+enter` が
Ghostty の split、`cmd+n` が Ghostty のウィンドウを作っていた。ペイン・タブ・
workspace の生成と移動をすべて herdr 側に寄せる。

## やったこと

| キー | before (Ghostty) | after (herdr) |
| --- | --- | --- |
| `cmd+enter` | `new_split:down` | `split_horizontal` (下に分割) |
| `cmd+shift+enter` | `new_split:right` | `split_vertical` (右に分割) |
| `cmd+n` | `new_window` (既定) | `new_workspace` |
| `cmd+t` | `new_tab` (既定) | `new_tab` |
| `cmd+w` | `close_surface` | `close_pane` |
| `cmd+←↓↑→` | `goto_split:*` | `focus_pane_*` |

転送は kitty keyboard protocol の CSI-u シーケンスで行う。`unbind` でも Ghostty が
super 付きキーを符号化するが、macOS 側で `cmd+矢印` などを横取りされた実績が
あるため、送るバイト列を `csi:` アクションで固定した。

`csi:<code>;<mod>u` の `<code>` はキーの Unicode コードポイント、`<mod>` は
`1 + shift(1) + alt(2) + ctrl(4) + super(8)`。

## 落としたもの

Ghostty の `resize_split` バインド。herdr に方向指定のリサイズを直接バインドする
口がないため、herdr の resize mode (`prefix+r`) に寄せた。

## 動作確認

- `task test` … 44 件パス (新規 13 件を含む)
- `task format` … パス
- `ghostty +validate-config` / `herdr config check` … いずれも ok

キー入力の実機確認は未実施。sandbox 内で pty を確保できずキーを注入できなかったため、
設定の妥当性と両ファイルの対応関係の検証にとどめている。

## 適用手順

merge 後、Ghostty は設定リロード (`cmd+shift+,`)、herdr は
`herdr server reload-config` で反映される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)