### PR TITLE
feat(ghostty): 残る split/タブ系キーも herdr へ委譲する

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -57,8 +57,10 @@ clipboard-write = allow
 # kitty keyboard protocol の CSI-u シーケンスとして herdr へ送る。
 #
 # csi:<code>;<mod>u の <code> はキーの Unicode コードポイント
-# (enter=13, n=110, t=116, w=119)、<mod> は 1 + shift(1) + alt(2) + ctrl(4)
-# + super(8)。つまり cmd = 9、cmd+shift = 10。矢印は CSI 1;<mod>A/B/C/D。
+# (tab=9, enter=13, d=100, n=110, t=116, w=119, [=91, ]=93)、<mod> は
+# 1 + shift(1) + alt(2) + ctrl(4) + super(8)。つまり cmd = 9、
+# cmd+shift = 10、ctrl = 5、ctrl+shift = 6、cmd+ctrl = 13。
+# 矢印は CSI 1;<mod>A/B/C/D。
 #
 # unbind でも Ghostty が super 付きキーを CSI-u に符号化するが、
 # macOS 側で cmd+矢印などを横取りされた実績があるため、送るバイト列を
@@ -81,9 +83,30 @@ keybind = cmd+right=csi:1;9C
 keybind = cmd+up=csi:1;9A
 keybind = cmd+down=csi:1;9B
 
-# ペインのリサイズは herdr の resize mode (prefix + r) を使う。
-# herdr に方向指定のリサイズを直接バインドする口がないため、
-# Ghostty 側の resize_split は持たない。
+# Cmd+D で「右に」分割 / Cmd+Shift+D で「下に」分割
+# (Ghostty 既定の new_split と同じ向きのまま herdr へ渡す)
+keybind = cmd+d=csi:100;9u
+keybind = cmd+shift+d=csi:100;10u
+
+# Cmd + [ / ] でペインを循環 (既定の goto_split の置き換え)
+keybind = cmd+[=csi:91;9u
+keybind = cmd+]=csi:93;9u
+
+# Cmd + Shift + [ / ] と Ctrl+Tab でタブ移動 (既定の previous/next_tab の置き換え)
+keybind = cmd+shift+[=csi:91;10u
+keybind = cmd+shift+]=csi:93;10u
+keybind = ctrl+tab=csi:9;5u
+keybind = ctrl+shift+tab=csi:9;6u
+
+# Cmd + Ctrl + 矢印キー でペインをリサイズ (既定の resize_split の置き換え)
+keybind = cmd+ctrl+left=csi:1;13D
+keybind = cmd+ctrl+right=csi:1;13C
+keybind = cmd+ctrl+up=csi:1;13A
+keybind = cmd+ctrl+down=csi:1;13B
+
+# 残る Ghostty 既定の split 系 (cmd+option+矢印 の goto_split、cmd+ctrl+= の
+# equalize_splits、cmd+1..9 の goto_tab) は、Ghostty 側にペインもタブも
+# 生えなくなるため何もしない no-op になる。あえて unbind はしない。
 
 #
 # その他

--- a/config/herdr/README.md
+++ b/config/herdr/README.md
@@ -17,16 +17,22 @@ Claude Code のプロンプトをタブ名へ反映するフックは
 
 | 操作 | キー | prefix 版 |
 | --- | --- | --- |
-| ペインを下に分割 | `cmd` + `enter` | `prefix` + `-` |
-| ペインを右に分割 | `cmd` + `shift` + `enter` | `prefix` + `v` |
+| ペインを下に分割 | `cmd` + `enter` / `cmd` + `shift` + `d` | `prefix` + `-` |
+| ペインを右に分割 | `cmd` + `shift` + `enter` / `cmd` + `d` | `prefix` + `v` |
 | ペイン間の移動 | `cmd` + `←↓↑→` | `prefix` + `h/j/k/l` |
+| ペインを循環 | `cmd` + `[` / `]` | `prefix` + `(shift) tab` |
+| ペインのリサイズ | `cmd` + `ctrl` + `←↓↑→` | `prefix` + `r` |
 | ペインを閉じる | `cmd` + `w` | `prefix` + `x` |
 | 新しい space (workspace) | `cmd` + `n` (`ctrl` + `n`) | `prefix` + `shift` + `n` |
 | 新しいタブ | `cmd` + `t` | `prefix` + `c` |
-| 前のタブ | `shift` + `←` / `↑` | `prefix` + `p` |
-| 次のタブ | `shift` + `→` / `↓` | `prefix` + `n` |
+| 前のタブ | `shift` + `←` / `↑`、`cmd` + `shift` + `[`、`ctrl` + `shift` + `tab` | `prefix` + `p` |
+| 次のタブ | `shift` + `→` / `↓`、`cmd` + `shift` + `]`、`ctrl` + `tab` | `prefix` + `n` |
 | 新しい claude エージェント | `ctrl` + `option` + `n` | (なし) |
-| ペインのリサイズ | (なし) | `prefix` + `r` |
+
+`cmd+d` / `cmd+[` / `cmd+shift+[` / `ctrl+tab` は Ghostty が既定で自分の
+split・タブ操作に使っていたキー。向きや役割は Ghostty 既定に合わせたまま
+herdr 側へ移してある。リサイズだけは herdr に方向指定のバインドがないため、
+`herdr pane resize` を叩くカスタムコマンドで実現している。
 
 変更後の反映は再起動不要で、`herdr server reload-config` で足りる。
 

--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -22,22 +22,25 @@ prompt_new_tab_name = false
 # 直接バインドしたキーは herdr が横取りするため、ペイン内のアプリ
 # (shell / vim / エージェント本体) には届かなくなる点に注意。
 
-# タブ移動: shift + ←/→ (↑/↓ も同義)
-previous_tab = ["shift+left", "shift+up"]
-next_tab = ["shift+right", "shift+down"]
-
-# ここから下の cmd 系は Ghostty が CSI-u で転送してくるキー。
+# ここから下の cmd 系と ctrl+tab は Ghostty が CSI-u で転送してくるキー。
 # config/ghostty/config の keybind = cmd+... = csi:... と対で維持する。
 
-# ペイン分割: cmd + enter で下、cmd + shift + enter で右
-split_horizontal = ["prefix+minus", "cmd+enter"]
-split_vertical = ["prefix+v", "cmd+shift+enter"]
+# タブ移動: shift + ←/→ (↑/↓ も同義)、cmd + shift + [ / ]、ctrl + tab
+previous_tab = ["shift+left", "shift+up", "cmd+shift+[", "ctrl+shift+tab"]
+next_tab = ["shift+right", "shift+down", "cmd+shift+]", "ctrl+tab"]
 
-# ペイン移動: cmd + 矢印
+# ペイン分割: cmd + enter で下、cmd + shift + enter で右
+# cmd + d / cmd + shift + d は Ghostty 既定の new_split と同じ向きに合わせる。
+split_horizontal = ["prefix+minus", "cmd+enter", "cmd+shift+d"]
+split_vertical = ["prefix+v", "cmd+shift+enter", "cmd+d"]
+
+# ペイン移動: cmd + 矢印、循環は cmd + [ / ]
 focus_pane_left = ["prefix+h", "cmd+left"]
 focus_pane_down = ["prefix+j", "cmd+down"]
 focus_pane_up = ["prefix+k", "cmd+up"]
 focus_pane_right = ["prefix+l", "cmd+right"]
+cycle_pane_previous = ["prefix+shift+tab", "cmd+["]
+cycle_pane_next = ["prefix+tab", "cmd+]"]
 
 # ペインを閉じる: cmd + w
 close_pane = ["prefix+x", "cmd+w"]
@@ -57,3 +60,30 @@ key = "ctrl+alt+n"
 type = "shell"
 command = "\"$HOME/.config/herdr/herdr-new-agent.sh\" claude"
 description = "start a new claude agent in a sibling pane"
+
+# ペインのリサイズ: cmd + ctrl + 矢印
+# herdr には方向指定のリサイズを直接バインドする口 (resize_mode 以外) が
+# ないため、CLI を叩くカスタムコマンドで代用する。
+[[keys.command]]
+key = "ctrl+cmd+left"
+type = "shell"
+command = '"${HERDR_BIN_PATH:-herdr}" pane resize --direction left --pane "$HERDR_ACTIVE_PANE_ID"'
+description = "resize the focused pane to the left"
+
+[[keys.command]]
+key = "ctrl+cmd+right"
+type = "shell"
+command = '"${HERDR_BIN_PATH:-herdr}" pane resize --direction right --pane "$HERDR_ACTIVE_PANE_ID"'
+description = "resize the focused pane to the right"
+
+[[keys.command]]
+key = "ctrl+cmd+up"
+type = "shell"
+command = '"${HERDR_BIN_PATH:-herdr}" pane resize --direction up --pane "$HERDR_ACTIVE_PANE_ID"'
+description = "resize the focused pane upward"
+
+[[keys.command]]
+key = "ctrl+cmd+down"
+type = "shell"
+command = '"${HERDR_BIN_PATH:-herdr}" pane resize --direction down --pane "$HERDR_ACTIVE_PANE_ID"'
+description = "resize the focused pane downward"

--- a/tests/ghostty-herdr-keys.bats
+++ b/tests/ghostty-herdr-keys.bats
@@ -51,6 +51,35 @@ herdr_action_for_key() {
   [ "$(ghostty_action 'cmd\+down')" = 'csi:1;9B' ]
 }
 
+@test "cmd+d 系は分割用の CSI-u を送る" {
+  # 100 = d の Unicode コードポイント
+  [ "$(ghostty_action 'cmd\+d')" = 'csi:100;9u' ]
+  [ "$(ghostty_action 'cmd\+shift\+d')" = 'csi:100;10u' ]
+}
+
+@test "cmd+[ / ] はペイン循環用の CSI-u を送る" {
+  # 91 = [、93 = ]
+  [ "$(ghostty_action 'cmd\+\[')" = 'csi:91;9u' ]
+  [ "$(ghostty_action 'cmd\+\]')" = 'csi:93;9u' ]
+}
+
+@test "タブ移動キーはタブ用の CSI-u を送る" {
+  # shift 付きでも送るのは非 shift のコードポイント + shift 修飾子
+  [ "$(ghostty_action 'cmd\+shift\+\[')" = 'csi:91;10u' ]
+  [ "$(ghostty_action 'cmd\+shift\+\]')" = 'csi:93;10u' ]
+  # 9 = tab、5 = 1 + ctrl(4)、6 = 1 + shift(1) + ctrl(4)
+  [ "$(ghostty_action 'ctrl\+tab')" = 'csi:9;5u' ]
+  [ "$(ghostty_action 'ctrl\+shift\+tab')" = 'csi:9;6u' ]
+}
+
+@test "cmd+ctrl+矢印はリサイズ用の CSI-u を送る" {
+  # 13 = 1 + ctrl(4) + super(8)
+  [ "$(ghostty_action 'cmd\+ctrl\+left')" = 'csi:1;13D' ]
+  [ "$(ghostty_action 'cmd\+ctrl\+right')" = 'csi:1;13C' ]
+  [ "$(ghostty_action 'cmd\+ctrl\+up')" = 'csi:1;13A' ]
+  [ "$(ghostty_action 'cmd\+ctrl\+down')" = 'csi:1;13B' ]
+}
+
 # =============================================================================
 # herdr 側: 転送されたキーを受け取るバインドがある
 # =============================================================================
@@ -80,6 +109,33 @@ herdr_action_for_key() {
   [ "$(herdr_action_for_key 'cmd\+down')" = "focus_pane_down" ]
   [ "$(herdr_action_for_key 'cmd\+up')" = "focus_pane_up" ]
   [ "$(herdr_action_for_key 'cmd\+right')" = "focus_pane_right" ]
+}
+
+@test "cmd+d 系が herdr の分割に割り当たっている" {
+  # Ghostty 既定と同じ向き: cmd+d が右、cmd+shift+d が下
+  [ "$(herdr_action_for_key 'cmd\+d')" = "split_vertical" ]
+  [ "$(herdr_action_for_key 'cmd\+shift\+d')" = "split_horizontal" ]
+}
+
+@test "cmd+[ / ] が herdr のペイン循環に割り当たっている" {
+  [ "$(herdr_action_for_key 'cmd\+\[')" = "cycle_pane_previous" ]
+  [ "$(herdr_action_for_key 'cmd\+\]')" = "cycle_pane_next" ]
+}
+
+@test "タブ移動キーが herdr のタブ移動に割り当たっている" {
+  [ "$(herdr_action_for_key 'cmd\+shift\+\[')" = "previous_tab" ]
+  [ "$(herdr_action_for_key 'cmd\+shift\+\]')" = "next_tab" ]
+  [ "$(herdr_action_for_key 'ctrl\+shift\+tab')" = "previous_tab" ]
+  [ "$(herdr_action_for_key 'ctrl\+tab')" = "next_tab" ]
+}
+
+@test "cmd+ctrl+矢印が herdr の pane resize コマンドに割り当たっている" {
+  local direction
+  for direction in left right up down; do
+    run grep -A3 -F "key = \"ctrl+cmd+${direction}\"" "$HERDR_CONFIG"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"pane resize --direction ${direction}"* ]]
+  done
 }
 
 # =============================================================================


### PR DESCRIPTION
## 概要

#86 の続き。`cmd+enter` / `cmd+n` / `cmd+t` / `cmd+w` / `cmd+矢印` は herdr へ回したが、
Ghostty 既定のキーにまだ自前の split とタブ操作が残っていた。実害があるのは Ghostty 側に
ペインを生やす `cmd+d` / `cmd+shift+d` なので、これらを含めて向きと役割を保ったまま
herdr へ移す。

## 変更

| キー | before (Ghostty 既定) | after (herdr) |
| --- | --- | --- |
| `cmd+d` | `new_split:right` | `split_vertical` (右に分割) |
| `cmd+shift+d` | `new_split:down` | `split_horizontal` (下に分割) |
| `cmd+[` / `cmd+]` | `goto_split:previous/next` | `cycle_pane_previous/next` |
| `cmd+shift+[` / `cmd+shift+]` | `previous_tab` / `next_tab` | `previous_tab` / `next_tab` |
| `ctrl+tab` / `ctrl+shift+tab` | `next_tab` / `previous_tab` | `next_tab` / `previous_tab` |
| `cmd+ctrl+←↓↑→` | `resize_split:*,10` | `herdr pane resize --direction *` |

リサイズは herdr に方向指定のバインドが (`resize_mode` 以外) ないため、herdr CLI を叩く
`[[keys.command]]` で実現している。#86 で落としたリサイズの復活でもある。

## 手を付けなかったもの

`cmd+option+矢印` (`goto_split`)、`cmd+ctrl+=` (`equalize_splits`)、`cmd+1..9`
(`goto_tab`) は Ghostty 側にペインもタブも生えなくなる以上 no-op になるため、あえて
`unbind` はしていない。

`cmd+1..9` を herdr の `switch_tab` に回すことも考えたが、Ghostty には
`super+1` と `super+digit_1` の2系統のトリガがあり、両方潰さないと片方が
先に食って無反応になる。17行の keybind を足す割に得るものが薄いので見送った。

## 動作確認

- `task test` … 52 件パス (この PR で 8 件追加)
- `task format` … パス
- `ghostty +validate-config` … rc=0
- `herdr config check` … ok (`cmd+[` や `ctrl+cmd+left` のようなキー名も受け付けることを、
  わざと壊した設定が弾かれることと合わせて確認済み)

キー入力の実機確認は未実施。sandbox 内で pty を確保できないため。

## 適用手順

merge 後、Ghostty は設定リロード (`cmd+shift+,`)、herdr は `herdr server reload-config`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)