### PR TITLE
feat(ghostty,git): 端末上の URL と PR 参照をクリックで開けるようにする

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -50,6 +50,29 @@ clipboard-read = allow
 clipboard-write = allow
 
 #
+# リンク (URL / PR 番号)
+#
+# URL の検出は Ghostty 内蔵。ホバー中に cmd を押すと下線が付き、
+# cmd + クリックで既定のブラウザが開く。この修飾キーは Ghostty 側で
+# ハードコードされていて、ダブルクリックや修飾キー無しには変更できない
+# (keybind にマウストリガーが無いため)。
+# 参考: https://github.com/ghostty-org/ghostty/discussions/4917
+link-url = true
+
+# リンクにポインタを合わせたときにリンク先を吹き出しで表示する。
+# OSC 8 ハイパーリンクは表示文字列とリンク先が別物になりうるので、
+# 飛び先を確認してから押せるように有効にしておく。
+link-previews = true
+
+# PR / issue の `#42` のような独自パターンをクリック可能にする `link`
+# オプションは Ghostty 1.3.1 時点では未実装で、設定すると
+# `ghostty +validate-config` が error.NotImplemented を返す。
+# 上流の方針も「端末側で任意の文字列をマッチさせるのではなく、出力する
+# ツールが OSC 8 を吐く」なので、git の出力は pager (config/git の
+# git-osc8-refs) 側で OSC 8 化して cmd + クリックできるようにしている。
+# 参考: https://github.com/ghostty-org/ghostty/discussions/4379
+
+#
 # ペイン操作 (herdr へ委譲)
 #
 # Ghostty は herdr を載せる器に徹する。ペイン / タブ / workspace の生成と

--- a/config/git/CLAUDE.md
+++ b/config/git/CLAUDE.md
@@ -21,6 +21,25 @@ Git のグローバル設定ファイル群を管理するディレクトリ。`
 - `git bare-clone <url>` - bare clone を `<ghq.root>/<host>/<owner>/<repo>/.git` に配置｡refspec 設定 & fetch & HEAD 自動設定まで一括実行
 - `git mc` - メインブランチに切替 + pull + `gh poi` でマージ済みブランチ削除
 
+### pager: issue / PR 参照のリンク化
+
+`[pager]` の `log` / `show` は `git-osc8-refs` を挟み、出力中の `#123` を OSC 8
+ハイパーリンクへ変換する (リンク先は origin から組み立てた
+`https://github.com/<owner>/<repo>/issues/<番号>`)。Ghostty 上で cmd + クリック、
+または less の `^O^N` / `^O^O` で開ける。
+
+- Ghostty 1.3.1 の `link` (任意の正規表現をクリック可能にする設定) は未実装なので、
+  端末側ではなく出力側で OSC 8 を吐く方式を採っている
+- `less` には `-R` が必須。付けないと OSC 8 が端末まで届かない
+- リンク先が決まらないとき (リポジトリ外・origin なし・GitHub 以外のホスト) は
+  入力をそのまま素通しする。pager は常に挟まるためエラー終了させてはいけない
+- GitHub Enterprise などは `GIT_OSC8_REFS_BASE` にリポジトリの Web URL を設定する
+- `owner/repo#99` (別リポジトリ参照) と `#42abcd` (16 進カラー) は変換しない。
+  ただし `#420` のような 3 桁の 16 進カラーは番号と区別できないため変換される
+
+なお、その上にある `[page]` セクションは `[pager]` の綴り間違いで git からは
+無視されている。挙動を変えないためそのまま残してある。
+
 ### git-wt (worktree) 設定
 
 `[wt]` セクションで worktree 作成時の挙動を制御:

--- a/config/git/config
+++ b/config/git/config
@@ -8,6 +8,15 @@
   log = diff-highlight | less
   show = diff-highlight | less
   diff = diff-highlight | less
+# 上の [page] は [pager] の綴り間違いで git からは無視されている
+# (diff-highlight も未インストール)。挙動を変えないためそのまま残し、
+# 実際に効かせる pager は以下の [pager] で定義する。
+[pager]
+  # `#42` のような issue / PR 参照を OSC 8 ハイパーリンクへ変換し、
+  # 端末上で cmd + クリックして開けるようにする。
+  # less には -R が要る (制御シーケンスをそのまま端末へ渡すため)。
+  log = ~/.config/git/git-osc8-refs | less -R
+  show = ~/.config/git/git-osc8-refs | less -R
 [pull]
   rebase = true
   ff = only

--- a/config/git/git-osc8-refs
+++ b/config/git/git-osc8-refs
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# 標準入力に含まれる GitHub の issue / PR 参照 (`#123`) を OSC 8
+# ハイパーリンクへ書き換えて標準出力へ流すフィルタ。
+#
+# Ghostty 1.3.1 時点では任意の正規表現をクリック可能にする `link` 設定が
+# 未実装 (error.NotImplemented) なので、番号参照は出力する側で OSC 8 に
+# しておく必要がある。git の pager として使う想定 (config の [pager] 参照)。
+#
+# リンク先は `<リポジトリの Web URL>/issues/<番号>`。GitHub は PR 番号を
+# /issues/ で開くと /pull/ へリダイレクトするため、issue と PR を区別しない。
+#
+# 認識するリモート URL:
+#   git@github.com:owner/repo(.git)
+#   ssh://git@github.com/owner/repo(.git)
+#   https://github.com/owner/repo(.git)
+#
+# GitHub Enterprise など上記に当てはまらない環境では GIT_OSC8_REFS_BASE に
+# リポジトリの Web URL を設定する。リンク先が決まらないとき (リポジトリ外、
+# origin なし、非対応ホスト) は入力をそのまま素通しする。pager として常に
+# 挟まるため、ここでエラー終了すると git の出力自体が壊れる。
+
+set -euo pipefail
+
+# リモート URL を GitHub の Web URL へ正規化して標準出力へ書く。
+# 変換できないときは何も書かずに 1 を返す。
+# $1: リモート URL
+normalize_remote_url() {
+  local url="$1"
+  local path
+
+  case "$url" in
+    git@github.com:*) path="${url#git@github.com:}" ;;
+    ssh://git@github.com/*) path="${url#ssh://git@github.com/}" ;;
+    https://github.com/*) path="${url#https://github.com/}" ;;
+    http://github.com/*) path="${url#http://github.com/}" ;;
+    *) return 1 ;;
+  esac
+
+  path="${path%/}"
+  path="${path%.git}"
+
+  # owner/repo の 2 階層ちょうどでなければ対象外
+  case "$path" in
+    */*/* | */ | /* | "") return 1 ;;
+    */*) ;;
+    *) return 1 ;;
+  esac
+
+  printf '%s\n' "https://github.com/$path"
+}
+
+# リンク先のベース URL を解決して標準出力へ書く。
+# 解決できないときは何も書かずに 1 を返す。
+resolve_base_url() {
+  if [ -n "${GIT_OSC8_REFS_BASE:-}" ]; then
+    printf '%s\n' "${GIT_OSC8_REFS_BASE%/}"
+    return 0
+  fi
+
+  local url
+  # リポジトリ外や origin 未設定は想定内なので fatal を出力へ混ぜない
+  if ! url=$(git config --get remote.origin.url 2>/dev/null); then
+    return 1
+  fi
+
+  normalize_remote_url "$url"
+}
+
+base=""
+if ! base=$(resolve_base_url); then
+  exec cat
+fi
+
+# `#123` の直前が英数字・`/`・`#` のときは別リポジトリ参照 (owner/repo#1) や
+# 16 進カラー (#42abcd) の可能性があるため書き換えない。ANSI SGR
+# シーケンス直後は色付き出力の途中なので対象に含める。\K で前方の
+# コンテキストを置換対象から外している。
+OSC8_BASE="$base" exec perl -pe '
+  BEGIN { $base = $ENV{OSC8_BASE} }
+  s{(?:^|\e\[[0-9;]*m|[^0-9A-Za-z_/\#-])\K\#([0-9]+)(?![0-9A-Za-z_-])}{\e]8;;$base/issues/$1\e\\\#$1\e]8;;\e\\}g
+'

--- a/tests/git-osc8-refs.bats
+++ b/tests/git-osc8-refs.bats
@@ -1,0 +1,231 @@
+#!/usr/bin/env bats
+# git-osc8-refs スクリプトのテスト
+# issue / PR 参照の OSC 8 変換、誤検出の抑止、リンク先を解決できない場合の
+# 素通しを、通常リポジトリ / bare / worktree の各コンテキストで検証する
+
+SCRIPT="$BATS_TEST_DIRNAME/../config/git/git-osc8-refs"
+GIT_CONFIG_FILE="$BATS_TEST_DIRNAME/../config/git/config"
+
+setup() {
+  ORIG_DIR="$PWD"
+  REPO="$BATS_TEST_TMPDIR/repo"
+  git init -q -b main "$REPO"
+  git -C "$REPO" remote add origin git@github.com:usadamasa/dotfile.git
+  git -C "$REPO" config user.email "test@example.com"
+  git -C "$REPO" config user.name "Test User"
+  cd "$REPO" || return 1
+  unset GIT_OSC8_REFS_BASE
+}
+
+teardown() {
+  cd "$ORIG_DIR" || return 0
+}
+
+# OSC 8 でリンク化されたテキストを組み立てる
+# $1: リンク先 URL / $2: 表示テキスト
+osc8() {
+  printf '\e]8;;%s\e\\%s\e]8;;\e\\' "$1" "$2"
+}
+
+# =============================================================================
+# 構文チェック
+# =============================================================================
+
+@test "スクリプトの構文が正しい" {
+  run bash -n "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# 変換される入力
+# =============================================================================
+
+@test "PR 参照 #87 が OSC 8 リンクになる" {
+  run bash "$SCRIPT" <<< 'Merge pull request #87 from usadamasa/x'
+
+  [ "$status" -eq 0 ]
+  link=$(osc8 'https://github.com/usadamasa/dotfile/issues/87' '#87')
+  [ "$output" = "Merge pull request $link from usadamasa/x" ]
+}
+
+@test "カッコで囲まれた (#1234) も変換される" {
+  run bash "$SCRIPT" <<< 'fix something (#1234).'
+
+  [ "$status" -eq 0 ]
+  link=$(osc8 'https://github.com/usadamasa/dotfile/issues/1234' '#1234')
+  [ "$output" = "fix something ($link)." ]
+}
+
+@test "行頭の #5 も変換される" {
+  run bash "$SCRIPT" <<< '#5 is done'
+
+  [ "$status" -eq 0 ]
+  link=$(osc8 'https://github.com/usadamasa/dotfile/issues/5' '#5')
+  [ "$output" = "$link is done" ]
+}
+
+@test "ANSI SGR シーケンス直後の #7 も変換される" {
+  run bash "$SCRIPT" <<< "$(printf '\e[33m#7\e[m')"
+
+  [ "$status" -eq 0 ]
+  link=$(osc8 'https://github.com/usadamasa/dotfile/issues/7' '#7')
+  [ "$output" = "$(printf '\e[33m')$link$(printf '\e[m')" ]
+}
+
+@test "1 行に複数ある参照がすべて変換される" {
+  run bash "$SCRIPT" <<< 'closes #1 and #2'
+
+  [ "$status" -eq 0 ]
+  one=$(osc8 'https://github.com/usadamasa/dotfile/issues/1' '#1')
+  two=$(osc8 'https://github.com/usadamasa/dotfile/issues/2' '#2')
+  [ "$output" = "closes $one and $two" ]
+}
+
+# =============================================================================
+# 変換してはいけない入力
+# =============================================================================
+
+@test "16 進カラー #42abcd は変換しない" {
+  run bash "$SCRIPT" <<< 'color: #42abcd;'
+
+  [ "$status" -eq 0 ]
+  [ "$output" = 'color: #42abcd;' ]
+}
+
+@test "別リポジトリ参照 owner/repo#99 は変換しない" {
+  run bash "$SCRIPT" <<< 'see usadamasa/other#99'
+
+  [ "$status" -eq 0 ]
+  [ "$output" = 'see usadamasa/other#99' ]
+}
+
+@test "番号を伴わない # は変換しない" {
+  run bash "$SCRIPT" <<< '# コメント行'
+
+  [ "$status" -eq 0 ]
+  [ "$output" = '# コメント行' ]
+}
+
+# =============================================================================
+# リンク先の解決
+# =============================================================================
+
+@test "https 形式のリモート URL を正規化する" {
+  git remote set-url origin https://github.com/usadamasa/dotfile.git
+  run bash "$SCRIPT" <<< 'see #3'
+
+  [ "$status" -eq 0 ]
+  link=$(osc8 'https://github.com/usadamasa/dotfile/issues/3' '#3')
+  [ "$output" = "see $link" ]
+}
+
+@test "ssh:// 形式のリモート URL を正規化する" {
+  git remote set-url origin ssh://git@github.com/usadamasa/dotfile.git
+  run bash "$SCRIPT" <<< 'see #3'
+
+  [ "$status" -eq 0 ]
+  link=$(osc8 'https://github.com/usadamasa/dotfile/issues/3' '#3')
+  [ "$output" = "see $link" ]
+}
+
+@test "GIT_OSC8_REFS_BASE が origin より優先され末尾スラッシュを落とす" {
+  export GIT_OSC8_REFS_BASE='https://ghe.example.com/o/r/'
+  run bash "$SCRIPT" <<< 'see #3'
+
+  [ "$status" -eq 0 ]
+  link=$(osc8 'https://ghe.example.com/o/r/issues/3' '#3')
+  [ "$output" = "see $link" ]
+}
+
+# =============================================================================
+# 素通しになる条件
+# =============================================================================
+
+@test "GitHub 以外のホストは素通しする" {
+  git remote set-url origin git@gitlab.com:usadamasa/dotfile.git
+  run bash "$SCRIPT" <<< 'see #3'
+
+  [ "$status" -eq 0 ]
+  [ "$output" = 'see #3' ]
+}
+
+@test "origin が無いリポジトリでは素通しする" {
+  git remote remove origin
+  run bash "$SCRIPT" <<< 'see #3'
+
+  [ "$status" -eq 0 ]
+  [ "$output" = 'see #3' ]
+}
+
+@test "リポジトリ外では素通しし標準出力に fatal を混ぜない" {
+  cd "$BATS_TEST_TMPDIR" || return 1
+  run bash "$SCRIPT" <<< 'see #3'
+
+  [ "$status" -eq 0 ]
+  [ "$output" = 'see #3' ]
+}
+
+# =============================================================================
+# git のコンテキスト別 (通常 clone / bare / worktree)
+# =============================================================================
+
+@test "通常 clone のコンテキストで変換される" {
+  clone="$BATS_TEST_TMPDIR/clone"
+  git clone -q "$REPO" "$clone"
+  git -C "$clone" remote set-url origin git@github.com:usadamasa/dotfile.git
+  cd "$clone" || return 1
+
+  run bash "$SCRIPT" <<< 'see #3'
+
+  [ "$status" -eq 0 ]
+  link=$(osc8 'https://github.com/usadamasa/dotfile/issues/3' '#3')
+  [ "$output" = "see $link" ]
+}
+
+@test "bare リポジトリのコンテキストで変換される" {
+  bare="$BATS_TEST_TMPDIR/bare.git"
+  git init -q --bare "$bare"
+  git -C "$bare" remote add origin git@github.com:usadamasa/dotfile.git
+  cd "$bare" || return 1
+
+  run bash "$SCRIPT" <<< 'see #3'
+
+  [ "$status" -eq 0 ]
+  link=$(osc8 'https://github.com/usadamasa/dotfile/issues/3' '#3')
+  [ "$output" = "see $link" ]
+}
+
+
+# =============================================================================
+# git config との対応
+# =============================================================================
+
+@test "pager.log と pager.show がこのスクリプトを経由する" {
+  for key in log show; do
+    value=$(git config --file "$GIT_CONFIG_FILE" --get "pager.$key")
+    [[ "$value" == *"git-osc8-refs"* ]]
+  done
+}
+
+@test "pager の less に -R が付いている" {
+  # -R が無いと OSC 8 が less に食われて端末まで届かない
+  for key in log show; do
+    value=$(git config --file "$GIT_CONFIG_FILE" --get "pager.$key")
+    [[ "$value" == *"less -R"* ]]
+  done
+}
+
+@test "worktree のコンテキストで変換される" {
+  echo initial > README.md
+  git add README.md
+  git commit -q -m 'Initial commit'
+  wt="$BATS_TEST_TMPDIR/wt"
+  git worktree add -q -b feature "$wt" >/dev/null
+  cd "$wt" || return 1
+
+  run bash "$SCRIPT" <<< 'see #3'
+
+  [ "$status" -eq 0 ]
+  link=$(osc8 'https://github.com/usadamasa/dotfile/issues/3' '#3')
+  [ "$output" = "see $link" ]
+}


### PR DESCRIPTION
## 背景

ターミナルに出る http リンクと PR の `#42` をクリックで開けるようにしたい、という要望から。

調べた結果、Ghostty 側だけでは要望どおりにできないことが分かった。

- Ghostty 1.3.1 の `link` (任意の正規表現をクリック可能にする設定) は未実装。
  実際に `link = ab,open` を書いて `ghostty +validate-config` にかけると
  `error.NotImplemented` で弾かれる ([discussion #4379](https://github.com/ghostty-org/ghostty/discussions/4379))
- リンクの起動方法は「ホバー + cmd + クリック」でハードコードされている。
  `keybind` にマウストリガーが無いため、ダブルクリックや修飾キー無しには変更できない
  ([discussion #4917](https://github.com/ghostty-org/ghostty/discussions/4917))
- 上流の方針は「端末側で任意の文字列をマッチさせるのではなく、出力するツールが
  OSC 8 を吐く」

そこで URL は Ghostty 内蔵の検出に任せ、`#42` は出力側で OSC 8 ハイパーリンクに
変換する方式にした。

## 変更内容

### `config/ghostty/config`

`link-url` / `link-previews` を明示的に設定し、上記の制約と回避策をコメントで残す。

### `config/git/git-osc8-refs` (新規)

標準入力の `#123` を `https://github.com/<owner>/<repo>/issues/<番号>` への
OSC 8 ハイパーリンクへ変換するフィルタ。GitHub は PR 番号を `/issues/` で開くと
`/pull/` へリダイレクトするため、issue と PR を区別していない。

- リンク先が決まらないとき (リポジトリ外・origin なし・GitHub 以外のホスト) は
  入力をそのまま素通しする。pager は常に挟まるのでエラー終了させてはいけない
- `owner/repo#99` (別リポジトリ参照) と `#42abcd` (16 進カラー) は変換しない
- GitHub Enterprise などは `GIT_OSC8_REFS_BASE` にリポジトリの Web URL を設定する

### `config/git/config`

`[pager]` の `log` / `show` に上記フィルタを挟む。`less -R` が必須
(付けないと OSC 8 が less に食われて端末まで届かない)。

なお、既存の `[page]` セクションは `[pager]` の綴り間違いで git からは無視されて
いる (`diff-highlight` も未インストール)。挙動を変えないためそのまま残した。

## 検証

- `task test`: 72 tests / 0 failures (新規 20 tests を含む)
- `task format`: pass
- `shellcheck config/git/git-osc8-refs`: pass
- `ghostty +validate-config --config-file=config/ghostty/config`: pass
- `less` の man で `-R` が OSC 8 hyperlink sequences を raw のまま出力することを確認
- herdr 0.8.0 のバイナリに `osc_hyperlink` / `visible_hyperlinks` の実装があることを確認

新規テストは通常 clone / bare / worktree の各コンテキストを含む
(プロジェクトスキル `git-context-testing` に準拠)。

## 残る制約

- **ダブルクリックでは開けない**。Ghostty の仕様上「ホバー + cmd + クリック」固定。
  less 上なら `^O^N` でリンク送り、`^O^O` で開くという操作も使える
- `#420` のような 3 桁の 16 進カラーは issue 番号と区別できないため変換される
- 変換対象は `git log` / `git show` の出力のみ。`gh` など他ツールの出力は対象外

## 適用方法

`config/git` は `~/.config/git` へディレクトリごと symlink されているため、
main へマージ後は追加の `task setup` なしで有効になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
