### PR TITLE
feat(ghostty,herdr): herdr 配下で実際に効く経路へ設定を寄せる

### DIFF
--- a/.zshenv
+++ b/.zshenv
@@ -18,6 +18,12 @@ export VIMDOTDIR="$XDG_CONFIG_HOME/vim"
 export LESSHISTFILE="$XDG_STATE_HOME/less/history"
 mkdir -p "$XDG_STATE_HOME/less"
 
+# less の ^O^O (OSC 8 ハイパーリンクを開く) を有効にする。
+# この変数が無いと ^O^N でリンクを選べても開けない。値はハンドラのシェル
+# コマンドで、その標準出力が opener として実行される (man less の推奨形)。
+# git log / show の `#42` は config/git/git-osc8-refs が OSC 8 化している。
+export LESS_OSC8_https="echo open '%o'"
+
 # sqlite
 export SQLITE_HISTORY="$XDG_CACHE_HOME/sqlite_history"
 mkdir -p "$SQLITE_HISTORY"

--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -31,8 +31,13 @@ minimum-contrast = 1.3
 
 # Mac標準の挙動にする
 macos-window-shadow = true
-macos-titlebar-style = tabs
 mouse-hide-while-typing = true
+
+# タイトルバーを隠して縦幅を稼ぐ。タブもペインも herdr 側に生えるので
+# Ghostty のタブバー (titlebar-style = tabs) は使い道がない。
+# 副作用: タイトルバー領域でのウィンドウドラッグができなくなる。動かすときは
+# 枠を option + クリックでドラッグする (Ghostty ではなく macOS 標準の挙動)。
+macos-titlebar-style = hidden
 
 # 背景を透過
 background-opacity = 0.90
@@ -52,24 +57,19 @@ clipboard-write = allow
 #
 # リンク (URL / PR 番号)
 #
-# URL の検出は Ghostty 内蔵。ホバー中に cmd を押すと下線が付き、
-# cmd + クリックで既定のブラウザが開く。この修飾キーは Ghostty 側で
-# ハードコードされていて、ダブルクリックや修飾キー無しには変更できない
-# (keybind にマウストリガーが無いため)。
-# 参考: https://github.com/ghostty-org/ghostty/discussions/4917
-link-url = true
-
-# リンクにポインタを合わせたときにリンク先を吹き出しで表示する。
-# OSC 8 ハイパーリンクは表示文字列とリンク先が別物になりうるので、
-# 飛び先を確認してから押せるように有効にしておく。
-link-previews = true
-
-# PR / issue の `#42` のような独自パターンをクリック可能にする `link`
-# オプションは Ghostty 1.3.1 時点では未実装で、設定すると
-# `ghostty +validate-config` が error.NotImplemented を返す。
-# 上流の方針も「端末側で任意の文字列をマッチさせるのではなく、出力する
-# ツールが OSC 8 を吐く」なので、git の出力は pager (config/git の
-# git-osc8-refs) 側で OSC 8 化して cmd + クリックできるようにしている。
+# link-url / link-previews は herdr 配下では効かないので設定しない。
+# herdr は各ペインの出力を自前でパースして再描画するため、URL 文字列も
+# OSC 8 ハイパーリンクも Ghostty までは届かず、cmd + クリックが反応しない
+# (実測済み)。herdr の [ui] mouse_capture = false でマウスを端末へ返せば
+# 動く余地はあるが、herdr 自身のマウス UI を失うので採らない。
+#
+# git log / show の `#42` を OSC 8 化する pager (config/git の git-osc8-refs) は
+# 残してあり、リンクを開く手段を less に一本化した。less の ^O^N で選び ^O^O で
+# 開く (.zshenv の LESS_OSC8_https が必要)。
+#
+# なお PR / issue の独自パターンを端末側でクリック可能にする `link` オプションは
+# Ghostty 1.3.1 時点で未実装 (設定すると +validate-config が
+# error.NotImplemented を返す)。
 # 参考: https://github.com/ghostty-org/ghostty/discussions/4379
 
 #
@@ -131,7 +131,16 @@ keybind = cmd+ctrl+down=csi:1;13B
 # equalize_splits、cmd+1..9 の goto_tab) は、Ghostty 側にペインもタブも
 # 生えなくなるため何もしない no-op になる。あえて unbind はしない。
 
+# Cmd+K で画面クリア。Ghostty 既定の clear_screen は herdr 配下では効かない
+# (herdr の TUI が上から描き直してしまう) ので、フォーカス中のペインのシェルへ
+# clear コマンドを打ち込む。
+keybind = cmd+k=text:clear\r
+
 #
 # その他
 #
-notify-on-command-finish = always
+# notify-on-command-finish は設定しない。コマンドの完了はシェルが出す OSC 133 で
+# 検知するが、これも herdr で止まって Ghostty には届かないため発火しない。
+# 同じ理由で jump_to_prompt と write_scrollback_file も機能しない
+# (スクロールバックは herdr の edit_scrollback = prefix+e を使う)。
+# 通知は herdr 側の [ui.toast] で受ける。

--- a/config/git/CLAUDE.md
+++ b/config/git/CLAUDE.md
@@ -25,12 +25,17 @@ Git のグローバル設定ファイル群を管理するディレクトリ。`
 
 `[pager]` の `log` / `show` は `git-osc8-refs` を挟み、出力中の `#123` を OSC 8
 ハイパーリンクへ変換する (リンク先は origin から組み立てた
-`https://github.com/<owner>/<repo>/issues/<番号>`)。Ghostty 上で cmd + クリック、
-または less の `^O^N` / `^O^O` で開ける。
+`https://github.com/<owner>/<repo>/issues/<番号>`)。less の `^O^N` でリンクを選び、
+`^O^O` で開く。
 
+- 開く手段は less に一本化している。端末の cmd + クリックは herdr 配下では効かない
+  (herdr が各ペインの出力を自前でパースして再描画するため、OSC 8 が端末まで
+  届かない)。この理由で `config/ghostty/config` の `link-url` は外してある
+- `^O^O` には `LESS_OSC8_https` の設定が必須 (`.zshenv` で定義)。無いとリンクを
+  選べても開けない
 - Ghostty 1.3.1 の `link` (任意の正規表現をクリック可能にする設定) は未実装なので、
   端末側ではなく出力側で OSC 8 を吐く方式を採っている
-- `less` には `-R` が必須。付けないと OSC 8 が端末まで届かない
+- `less` には `-R` が必須。付けないと OSC 8 が less から先へ渡らない
 - リンク先が決まらないとき (リポジトリ外・origin なし・GitHub 以外のホスト) は
   入力をそのまま素通しする。pager は常に挟まるためエラー終了させてはいけない
 - GitHub Enterprise などは `GIT_OSC8_REFS_BASE` にリポジトリの Web URL を設定する

--- a/config/git/ignore
+++ b/config/git/ignore
@@ -1,5 +1,6 @@
 PLAN.md
 
+.playwright-mcp/
 .claude/worktrees/
 CLAUDE.local.md
 typescript

--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -17,6 +17,7 @@ sidebar_min_width = 36
 
 prompt_new_tab_name = false
 
+agent_panel_sort = "priority"
 [keys]
 # 既定の prefix 方式は残したまま、よく使う操作にだけ直接バインドを足す。
 # 直接バインドしたキーは herdr が横取りするため、ペイン内のアプリ

--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -18,6 +18,32 @@ sidebar_min_width = 36
 prompt_new_tab_name = false
 
 agent_panel_sort = "priority"
+
+# ペイン間の隙間を詰める (共有の仕切り線だけにする)。
+pane_gaps = false
+
+# タブが 1 枚しかないワークスペースではタブ行を隠す。
+hide_tab_bar_when_single_tab = true
+
+# 選択しただけでクリップボードへコピー。Ghostty 側にも copy-on-select はあるが、
+# マウスを握っているのは herdr なので実効はこちら。
+copy_on_select = true
+
+# サイドバーの行構成。エージェントは「状態 + workspace」と端末タイトルの 2 行、
+# space は「状態 + workspace + ブランチ + git の状態」の 1 行にまとめる。
+[ui.sidebar.agents]
+row_gap = 0
+rows = [
+  ["state_icon", "workspace"],
+  ["terminal_title_stripped"],
+]
+
+[ui.sidebar.spaces]
+row_gap = 0
+rows = [
+  ["state_icon", "workspace", "branch", "git_status"],
+]
+
 [keys]
 # 既定の prefix 方式は残したまま、よく使う操作にだけ直接バインドを足す。
 # 直接バインドしたキーは herdr が横取りするため、ペイン内のアプリ
@@ -54,6 +80,13 @@ new_workspace = ["prefix+shift+n", "ctrl+n", "cmd+n"]
 # 新しいタブ: cmd + t
 new_tab = ["prefix+c", "cmd+t"]
 
+# ペインのリサイズ: cmd + ctrl + 矢印
+# resize_mode (prefix+r) に入らず直接リサイズする。
+resize_pane_left = ["ctrl+cmd+left"]
+resize_pane_down = ["ctrl+cmd+down"]
+resize_pane_up = ["ctrl+cmd+up"]
+resize_pane_right = ["ctrl+cmd+right"]
+
 # 新しいエージェント (claude): ctrl + option + n
 # 現在のペインを分割し、空いたペインで claude を起動する。
 [[keys.command]]
@@ -62,29 +95,13 @@ type = "shell"
 command = "\"$HOME/.config/herdr/herdr-new-agent.sh\" claude"
 description = "start a new claude agent in a sibling pane"
 
-# ペインのリサイズ: cmd + ctrl + 矢印
-# herdr には方向指定のリサイズを直接バインドする口 (resize_mode 以外) が
-# ないため、CLI を叩くカスタムコマンドで代用する。
+# フローティングの scratch shell: prefix + shift + c
+# popup は中のコマンドが終わると閉じる。Ghostty の quick terminal は
+# command = herdr を起動して既存セッションへ attach してしまうので使えない。
 [[keys.command]]
-key = "ctrl+cmd+left"
-type = "shell"
-command = '"${HERDR_BIN_PATH:-herdr}" pane resize --direction left --pane "$HERDR_ACTIVE_PANE_ID"'
-description = "resize the focused pane to the left"
-
-[[keys.command]]
-key = "ctrl+cmd+right"
-type = "shell"
-command = '"${HERDR_BIN_PATH:-herdr}" pane resize --direction right --pane "$HERDR_ACTIVE_PANE_ID"'
-description = "resize the focused pane to the right"
-
-[[keys.command]]
-key = "ctrl+cmd+up"
-type = "shell"
-command = '"${HERDR_BIN_PATH:-herdr}" pane resize --direction up --pane "$HERDR_ACTIVE_PANE_ID"'
-description = "resize the focused pane upward"
-
-[[keys.command]]
-key = "ctrl+cmd+down"
-type = "shell"
-command = '"${HERDR_BIN_PATH:-herdr}" pane resize --direction down --pane "$HERDR_ACTIVE_PANE_ID"'
-description = "resize the focused pane downward"
+key = "prefix+shift+c"
+type = "popup"
+command = "zsh"
+width = "90%"
+height = "85%"
+description = "floating shell popup"

--- a/tests/ghostty-herdr-keys.bats
+++ b/tests/ghostty-herdr-keys.bats
@@ -129,13 +129,11 @@ herdr_action_for_key() {
   [ "$(herdr_action_for_key 'ctrl\+tab')" = "next_tab" ]
 }
 
-@test "cmd+ctrl+矢印が herdr の pane resize コマンドに割り当たっている" {
-  local direction
-  for direction in left right up down; do
-    run grep -A3 -F "key = \"ctrl+cmd+${direction}\"" "$HERDR_CONFIG"
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"pane resize --direction ${direction}"* ]]
-  done
+@test "cmd+ctrl+矢印が herdr のペインリサイズに割り当たっている" {
+  [ "$(herdr_action_for_key 'ctrl\+cmd\+left')" = "resize_pane_left" ]
+  [ "$(herdr_action_for_key 'ctrl\+cmd\+down')" = "resize_pane_down" ]
+  [ "$(herdr_action_for_key 'ctrl\+cmd\+up')" = "resize_pane_up" ]
+  [ "$(herdr_action_for_key 'ctrl\+cmd\+right')" = "resize_pane_right" ]
 }
 
 # =============================================================================

--- a/tests/herdr-new-agent.bats
+++ b/tests/herdr-new-agent.bats
@@ -31,6 +31,10 @@ MOCK
   chmod +x "$MOCK_BIN/herdr"
 
   export PATH="$MOCK_BIN:$PATH"
+  # スクリプトは "${HERDR_BIN_PATH:-herdr}" を呼ぶ。herdr のペイン内で実行すると
+  # 実環境の HERDR_BIN_PATH (本物のバイナリ) が漏れてモックが使われないため、
+  # 実環境と同じくこの変数を明示し、モックを指すようにする。
+  export HERDR_BIN_PATH="$MOCK_BIN/herdr"
   export HERDR_ACTIVE_PANE_ID="wA:p1"
   export HERDR_ACTIVE_PANE_CWD="/repo/a"
 }


### PR DESCRIPTION
## Summary

[victor_wu の投稿](https://x.com/victor_wu/status/2090064806674145590) と、同趣旨の
[victor-falcon の gist](https://gist.github.com/victor-falcon/40838b25b721be48a7b828b676fd8c41)
を参考に、Ghostty + herdr の設定を見直した。

Ghostty は herdr を載せる器に徹しているため、ペインの出力経路に依存する端末側の機能は
herdr で止まって届かない。実測で効かないと確認できたものを外し、同じ用途を herdr 側の
機能へ移している。

### Ghostty

- `macos-titlebar-style` を `tabs` から `hidden` へ。タブは herdr 側に生えるので
  Ghostty のタブバーは使い道がない
- `cmd+k` に `text:clear\r` を追加。既定の `clear_screen` は herdr の TUI が上から
  描き直すため効かない
- `link-url` / `link-previews` を削除。OSC 8 も URL 文字列も herdr で止まるので
  cmd + クリックが反応しない
- `notify-on-command-finish` を削除。OSC 133 が届かないため発火しない

### herdr

- `ctrl+cmd+矢印` のリサイズを、CLI を叩く `[[keys.command]]` 4 本から `resize_pane_*` へ
  置換。0.8.2 で方向指定のバインドが追加されている
- `prefix+shift+c` にフローティングの scratch shell を追加。Ghostty の quick terminal は
  `command = herdr` を起動して既存セッションへ attach してしまうため使えない
- `pane_gaps` / `hide_tab_bar_when_single_tab` / `copy_on_select` とサイドバーの行構成

### less

- `LESS_OSC8_https` を定義。`git-osc8-refs` が吐く OSC 8 リンクは、この変数がないと
  `^O^N` で選べても `^O^O` で開けなかった。リンクを開く手段を less に一本化する

### tests

- リサイズのテストを `resize_pane_*` に追随
- `herdr-new-agent` のテストで `HERDR_BIN_PATH` を明示。herdr 0.8.2 がこの変数を
  export するようになり、実バイナリがモックより優先されて 8 件が失敗していた
  (**この変更以前から**の失敗。main でも再現することを worktree で確認済み)

## Test plan

```
task test    → 72 件すべて ok (失敗 0)
task format  → 通過
ghostty +validate-config --config-file=config/ghostty/config → exit 0
herdr config check       → config: ok
herdr server reload-config → status: applied, diagnostics: []
```

検証ツール自体の信頼性も確認した。

- `ghostty +validate-config` は不正な値 (`macos-titlebar-style = bogus`) で exit 1
- `herdr config check` は型不正 (`resize_pane_left = 12345`) と未知キー
  (`bogus_action_name`) の両方で exit 1
- `LESS_OSC8_https` はクリーンな環境 (`env -i`) から zsh を起こして値が入ることを確認

### 手動確認が必要なもの

- [ ] `macos-titlebar-style = hidden` — 実行中のウィンドウには適用されないため、
      新しいウィンドウで確認する。タイトルバー領域でのドラッグができなくなる
      (枠を option + クリックで代替) 点の使用感
- [ ] `ctrl+cmd+矢印` のリサイズと `prefix+shift+c` の popup (herdr は reload 済み)
- [ ] `git log` で `#42` に対する `^O^N` → `^O^O` (新しいシェルが必要)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
