### PR TITLE
fix(herdr): タブ行を常に表示する

### DIFF
--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -22,8 +22,9 @@ agent_panel_sort = "priority"
 # ペイン間の隙間を詰める (共有の仕切り線だけにする)。
 pane_gaps = false
 
-# タブが 1 枚しかないワークスペースではタブ行を隠す。
-hide_tab_bar_when_single_tab = true
+# タブ行は常に表示する。ワークスペースは 1 タブで運用することが多く、隠すと
+# タブの存在自体とアクティブなタブ名が画面から消えてしまう。
+hide_tab_bar_when_single_tab = false
 
 # 選択しただけでクリップボードへコピー。Ghostty 側にも copy-on-select はあるが、
 # マウスを握っているのは herdr なので実効はこちら。


### PR DESCRIPTION
## 背景

前の PR (#89) で追加した `hide_tab_bar_when_single_tab = true` により、herdr のタブ行が画面から消えていた。

`session.json` を確認したところ、開いている 3 つのワークスペース (twigpui / claude-config / dotfile) がすべて `tabs=1` で、「タブが 1 枚のときは隠す」条件に全件が該当していた。

## 変更

- `hide_tab_bar_when_single_tab` を `false` に戻す
- コメントを実態に合わせて書き直す

ワークスペースを 1 タブで運用することが多いため、この設定ではタブの存在自体とアクティブなタブ名が常に見えなくなる。

## 確認

- `herdr server reload-config` で稼働中のサーバーへ反映し、タブ行の再表示を確認済み
- bats テスト 72 件すべて green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rWn6ZfWWJDq4gsQBDnxyj
